### PR TITLE
Only allow pnpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ dist
 .svelte-kit
 
 # End of https://www.toptal.com/developers/gitignore/api/node,macos
+
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "rollup-plugin-esbuild": "^4.8.2",
     "typescript": "^4.5.4",
     "vitest": "^0.0.139"
+  },
+  "scripts": {
+    "preinstall": "npx only-allow pnpm"
   }
 }


### PR DESCRIPTION
With the goal of eliminating the inconsistencies that might arise as a result of using different dependency managers across environments, I'm adding a preinstall script in the root's package.json that ensures everyone is using [pnpm](https://pnpm.io/). Why are we using pnpm? It's faster and disk-space efficient.