### PR TITLE
Use multiple inputs when bundling the CLI

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "linked": [
     [
-      "@gestaltjs/gestalt",
+      "gestaltjs",
       "@gestaltjs/core",
       "@gestaltjs/build",
       "@gestaltjs/test",

--- a/.changeset/gold-houses-perform.md
+++ b/.changeset/gold-houses-perform.md
@@ -1,0 +1,5 @@
+---
+"gestaltjs": minor
+---
+
+Optimize the bundled Javascript code to share code across all the commands

--- a/packages/gestalt/rollup.config.js
+++ b/packages/gestalt/rollup.config.js
@@ -27,7 +27,7 @@ const configuration = () => [
             // Preserves the commands/... path
             return `commands/${chunkInfo.facadeModuleId
               .split('src/cli/commands')
-              .at(-1)
+              .slice(-1)[0]
               .replace('ts', 'js')}`;
           } else {
             return '[name].js';

--- a/packages/gestalt/rollup.config.js
+++ b/packages/gestalt/rollup.config.js
@@ -8,39 +8,36 @@ const gestaltPlugins = [
   ...plugins(__dirname),
 ]
 const gestaltFeatures = ['build', 'db', 'lint', 'serve', 'test', 'type-check'];
+const gestaltCommands = gestaltFeatures.flatMap((feature) => {
+  return fg.sync([
+    path.join(__dirname, `../${feature}/src/cli/commands/**/*.ts`),
+    `!${path.join(__dirname, `../${feature}/src/cli/commands/**/*.test.ts`)}`,
+  ]);
+})
 
 const configuration = () => [
   {
-    input: path.join(__dirname, 'src/index.ts'),
+    input: [path.join(__dirname, 'src/index.ts'), ...gestaltCommands],
     output: [
       {
-        file: path.join(distDir(__dirname), 'index.js'),
+        dir: distDir(__dirname),
         format: 'esm',
-        exports: 'auto',
+        entryFileNames: (chunkInfo) => {
+          if (chunkInfo.facadeModuleId.includes('src/cli/commands')) {
+            // Preserves the commands/... path
+            return `commands/${chunkInfo.facadeModuleId
+              .split('src/cli/commands')
+              .at(-1)
+              .replace('ts', 'js')}`;
+          } else {
+            return '[name].js';
+          }
+        },
       },
     ],
     plugins: gestaltPlugins,
     external: gestaltExternal,
-  },
-  ...gestaltFeatures.flatMap((feature) => {
-    const commands = fg.sync([
-      path.join(__dirname, `../${feature}/src/cli/commands/**/*.ts`),
-      `!${path.join(__dirname, `../${feature}/src/cli/commands/**/*.test.ts`)}`,
-    ]);
-    return commands.map((commandPath) => {
-      const outputPath = path.join(
-        distDir(__dirname),
-        'commands',
-        commandPath.split('src/cli/commands')[1].replace('.ts', '.js'),
-      );
-      return {
-        input: commandPath,
-        output: [{file: outputPath, format: 'esm', exports: 'default'}],
-        plugins: plugins(__dirname),
-        external: [...external, ...gestaltExternal],
-      };
-    });
-  }),
+  }
 ];
 
 export default configuration;


### PR DESCRIPTION
I noticed the Rollup configuration for the `gestalt` CLI can be configured differently using multiple inputs. Thanks to that, the code that's shared across all the commands will be automatically [code-splitted](https://rollupjs.org/guide/en/#code-splitting) by Rollup and generated in a shared `.js` file.