### PR TITLE
Build improvements

### DIFF
--- a/bin/create-app
+++ b/bin/create-app
@@ -2,7 +2,7 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-pushd $SCRIPT_DIR/..
-$SCRIPT_DIR/../node_modules/.bin/nx build @gestaltjs/create-app --baseHref $SCRIPT_DIR/..
+pushd $SCRIPT_DIR/.. > /dev/null
+$SCRIPT_DIR/../node_modules/.bin/nx build @gestaltjs/create-app
 $SCRIPT_DIR/../packages/create-app/bin/dev.js $@
-popd
+popd > /dev/null

--- a/bin/gestalt
+++ b/bin/gestalt
@@ -2,7 +2,7 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-pushd $SCRIPT_DIR/..
-$SCRIPT_DIR/../node_modules/.bin/nx build gestaltjs --baseHref $SCRIPT_DIR/..
+pushd $SCRIPT_DIR/.. > /dev/null
+$SCRIPT_DIR/../node_modules/.bin/nx build gestaltjs
 $SCRIPT_DIR/../packages/gestaltjs/bin/dev.js $@
-popd
+popd > /dev/null

--- a/packages/gestaltjs/rollup.config.js
+++ b/packages/gestaltjs/rollup.config.js
@@ -8,12 +8,7 @@ import {
   features,
 } from '../../configurations/rollup.config'
 
-const gestaltExternal = [
-  ...external,
-  '@oclif/core',
-  '@gestaltjs/core/cli',
-  '@gestaltjs/core/framework',
-]
+const gestaltExternal = [...external, '@oclif/core', /@gestaltjs\/core/]
 const gestaltPlugins = [...plugins(__dirname)]
 const gestaltCommands = features.flatMap((feature) => {
   return fg.sync([


### PR DESCRIPTION
## What?

- Don't print the executable path when running `gestalt` or `create-app`
- Remove unnecessary argument when calling Nx.
- Configure Rollup to treat `@gestaltjs/core` as external dependencies

## Why?
While running the Gestalt, I noticed some warnings that were telling us that the setup is not correct. This PR fixes them.

## Testing?

1. Check out the branch.
2. Run `gestalt`
  - You shouldn't see warnings
  - You shouldn't see the executable path printed

## Screenshots (optional)

**Warnings**
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/663605/156875926-fb710926-a8a4-487a-b7f1-7f0fa8309311.png">

**Path being printed**
<img width="438" alt="image" src="https://user-images.githubusercontent.com/663605/156875937-4e426721-89d3-4c25-8055-344aeb0b09d4.png">