### PR TITLE
Set up code coverage with codecov

### DIFF
--- a/.github/workflows/gestalt.yml
+++ b/.github/workflows/gestalt.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Build
-        run: npx nx --target=build --parallel=3
+        run: npx nx run-many --target=build --all --parallel=3
       - name: Test
-        run: npx nx --target=test:ci --parallel=3
+        run: npx nx run-many --target=test:ci --all --parallel=3
       - name: Lint
-        run: npx nx --target=lint --parallel=3
+        run: npx nx run-many --target=lint --all --parallel=3
       - name: Type-check
         run: npx nx --target=tsc --parallel=3
       - uses: codecov/codecov-action@v2
@@ -78,11 +78,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Build
-        run: npx nx --target=build --parallel=3
+        run: npx nx run-many --target=build --all --parallel=3
       - name: Test
-        run: npx nx --target=test:ci --parallel=3
+        run: npx nx run-many --target=test:ci --all --all --parallel=3
       - name: Lint
-        run: npx nx --target=lint --parallel=3
+        run: npx nx run-many --target=lint --all --parallel=3
       - name: Type-check
         run: npx nx --target=tsc --parallel=3
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/gestalt.yml
+++ b/.github/workflows/gestalt.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Type-check
         run: npx nx run-many --target=tsc --all --parallel=3
       - uses: codecov/codecov-action@v2
+        if: ${{ matrix.node == '17' && matrix.os == 'ubuntu-latest' }} # Only run the upload once
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/*/junit-*.xml
@@ -86,6 +87,7 @@ jobs:
       - name: Type-check
         run: npx nx run-many --target=tsc --all --parallel=3
       - uses: codecov/codecov-action@v2
+        if: ${{ matrix.node == '17' && matrix.os == 'ubuntu-latest' }} # Only run the upload once
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/*/junit-*.xml

--- a/.github/workflows/gestalt.yml
+++ b/.github/workflows/gestalt.yml
@@ -40,11 +40,17 @@ jobs:
       - name: Build
         run: npx nx --target=build --parallel=3
       - name: Test
-        run: npx nx --target=test --parallel=3
+        run: npx nx --target=test:ci --parallel=3
       - name: Lint
         run: npx nx --target=lint --parallel=3
       - name: Type-check
         run: npx nx --target=tsc --parallel=3
+      - uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/*/junit-*.xml
+          fail_ci_if_error: false
+          verbose: true
   main:
     name: Node ${{ matrix.node }} in ${{ matrix.os }}
     runs-on: ubuntu-latest
@@ -74,8 +80,14 @@ jobs:
       - name: Build
         run: npx nx --target=build --parallel=3
       - name: Test
-        run: npx nx --target=test --parallel=3
+        run: npx nx --target=test:ci --parallel=3
       - name: Lint
         run: npx nx --target=lint --parallel=3
       - name: Type-check
         run: npx nx --target=tsc --parallel=3
+      - uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/*/junit-*.xml
+          fail_ci_if_error: false
+          verbose: true

--- a/.github/workflows/gestalt.yml
+++ b/.github/workflows/gestalt.yml
@@ -38,13 +38,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Build
-        run: npx nx affected --target=build --parallel=3
+        run: npx nx --target=build --parallel=3
       - name: Test
-        run: npx nx affected --target=test --parallel=3
+        run: npx nx --target=test --parallel=3
       - name: Lint
-        run: npx nx affected --target=lint --parallel=3
+        run: npx nx --target=lint --parallel=3
       - name: Type-check
-        run: npx nx affected --target=tsc --parallel=3
+        run: npx nx --target=tsc --parallel=3
   main:
     name: Node ${{ matrix.node }} in ${{ matrix.os }}
     runs-on: ubuntu-latest
@@ -72,10 +72,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Build
-        run: npx nx affected --target=build --parallel=3
+        run: npx nx --target=build --parallel=3
       - name: Test
-        run: npx nx affected --target=test --parallel=3
+        run: npx nx --target=test --parallel=3
       - name: Lint
-        run: npx nx affected --target=lint --parallel=3
+        run: npx nx --target=lint --parallel=3
       - name: Type-check
-        run: npx nx affected --target=tsc --parallel=3
+        run: npx nx --target=tsc --parallel=3

--- a/.github/workflows/gestalt.yml
+++ b/.github/workflows/gestalt.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Lint
         run: npx nx run-many --target=lint --all --parallel=3
       - name: Type-check
-        run: npx nx --target=tsc --parallel=3
+        run: npx nx run-many --target=tsc --all --parallel=3
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -84,7 +84,7 @@ jobs:
       - name: Lint
         run: npx nx run-many --target=lint --all --parallel=3
       - name: Type-check
-        run: npx nx --target=tsc --parallel=3
+        run: npx nx run-many --target=tsc --all --parallel=3
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,5 @@ package-lock.json
 TODO.md
 
 vite.config.ts.js
+
+junit-*.xml

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
   <img src="https://github.com/gestaltjs/gestalt/workflows/Gestalt/badge.svg" alt="Gestalt">
   <img src="https://img.shields.io/github/forks/gestaltjs/gestalt?style=flat-square" alt="GitHub forks">
   <img src="https://img.shields.io/github/stars/gestaltjs/gestalt?style=flat-square" alt="GitHub stars">
+  <a href="https://codecov.io/gh/gestaltjs/gestalt">
+    <img src="https://codecov.io/gh/gestaltjs/gestalt/branch/main/graph/badge.svg?token=7L99SA0SLV"/>
+  </a>
   <img src="https://img.shields.io/github/commit-activity/w/gestaltjs/gestalt?style=flat-square" alt="Commit Activity">
   <img src="https://img.shields.io/github/contributors/gestaltjs/gestalt?style=flat-square" alt="Contributors">
   <img src="https://img.shields.io/github/commits-since/gestaltjs/gestalt/latest?style=flat-square" alt="Latest Commits">

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -17,6 +17,7 @@
     "lint:fix": "prettier -w src/** && eslint src/**/*.ts --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit-build.xml",
     "tsc": "tsc --noEmit"
   },
   "eslintConfig": {

--- a/packages/check/package.json
+++ b/packages/check/package.json
@@ -18,6 +18,7 @@
     "lint:fix": "prettier -w src/** && eslint src/**/*.ts --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit-check.xml",
     "tsc": "tsc --noEmit"
   },
   "eslintConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
     "lint:fix": "prettier -w src/** && eslint src/**/*.ts --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit-core.xml",
     "tsc": "tsc --noEmit"
   },
   "eslintConfig": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -31,6 +31,7 @@
     "lint:fix": "prettier -w src/** && eslint src/**/*.ts --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit-create-app.xml",
     "tsc": "tsc --noEmit"
   },
   "eslintConfig": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -18,6 +18,7 @@
     "lint:fix": "prettier -w src/** && eslint src/**/*.ts --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit-db.xml",
     "tsc": "tsc --noEmit"
   },
   "eslintConfig": {

--- a/packages/gestaltjs/package.json
+++ b/packages/gestaltjs/package.json
@@ -31,6 +31,7 @@
     "lint:fix": "prettier -w src/** && eslint src/**/*.ts --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit-gestaltjs.xml",
     "tsc": "tsc --noEmit"
   },
   "eslintConfig": {

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -18,6 +18,7 @@
     "lint:fix": "prettier -w src/** && eslint src/**/*.ts --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit-lint.xml",
     "tsc": "tsc --noEmit"
   },
   "eslintConfig": {

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -18,6 +18,7 @@
     "lint:fix": "prettier -w src/** && eslint src/**/*.ts --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit-serve.xml",
     "tsc": "tsc --noEmit"
   },
   "eslintConfig": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -18,6 +18,7 @@
     "lint:fix": "prettier -w src/** && eslint src/**/*.ts --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit-test.xml",
     "tsc": "tsc --noEmit"
   },
   "eslintConfig": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -27,6 +27,7 @@
     "lint:fix": "prettier -w src/** && eslint src/**/*.ts --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit-testing.xml",
     "tsc": "tsc --noEmit"
   },
   "eslintConfig": {


### PR DESCRIPTION
## What?
I'm integrating [codecov](https://app.codecov.io/) into this repository to get code coverage insights and reports on PRs.

## Why?
Although high test coverage might not necessarily lead to reliable software that does what's supposed to do, specially if the tests are not well written, it creates awareness and that's better than nothing. 

## How?

- Installed codecov's GitHub app in the organization.
- Added a new script, `test:ci` that runs the tests and outputs the results as a junit file.
- Extended the CI pipeline to upload the results using codecov's GitHub action.

## Testing?
- You can run `pnpm run lint:ci` in any of the packages and you should get a `junit` file generated in the folder of the package.
- We should see the codecov reports in this PR if the upload runs successfully.