### PR TITLE
Introduce the concept of renderers

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,7 +12,8 @@
       "@gestaltjs/db",
       "@gestaltjs/dev",
       "@gestaltjs/test",
-      "@gestaltjs/core"
+      "@gestaltjs/core",
+      "@gestaltjs/renderer"
     ]
   ],
   "access": "public",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,8 @@
       "@gestaltjs/dev",
       "@gestaltjs/test",
       "@gestaltjs/core",
-      "@gestaltjs/renderer"
+      "@gestaltjs/renderer",
+      "@gestaltjs/vue-gestalt-renderer"
     ]
   ],
   "access": "public",

--- a/configurations/rollup.config.js
+++ b/configurations/rollup.config.js
@@ -31,6 +31,10 @@ export const aliases = (packageDir) => {
       replacement: path.join(__dirname, '../packages/testing/src/index.ts'),
     },
     {
+      find: '@gestaltjs/renderer',
+      replacement: path.join(__dirname, '../packages/renderer/src/index.ts'),
+    },
+    {
       find: new RegExp('^\\$(.*)$'),
       replacement: path.join(packageDir, './src/$1.ts'),
     },
@@ -42,7 +46,7 @@ export const plugins = (packageDir) => {
     stripShebang(),
     resolve({
       preferBuiltins: true,
-      aliases: aliases
+      aliases: aliases,
     }),
     commonjs({
       include: /node_modules/,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,80 +1,81 @@
 {
-    "name": "@gestaltjs/core",
-    "version": "0.7.3",
-    "private": false,
-    "description": "Set of Getalt tools and models that are shared across all the features",
-    "keywords": [
-        "gestalt",
-        "gestaltjs",
-        "web"
-    ],
-    "license": "MIT",
-    "type": "module",
-    "exports": {
-        "./cli": {
-            "import": "./dist/cli/index.js",
-            "types": "./dist/cli/index.d.ts"
-        },
-        "./framework": {
-            "import": "./dist/framework/index.js",
-            "types": "./dist/framework/index.d.ts"
-        },
-        "./shared": {
-            "import": "./dist/shared/index.js",
-            "types": "./dist/shared/index.d.ts"
-        }
+  "name": "@gestaltjs/core",
+  "version": "0.7.3",
+  "private": false,
+  "description": "Set of Getalt tools and models that are shared across all the features",
+  "keywords": [
+    "gestalt",
+    "gestaltjs",
+    "web"
+  ],
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./cli": {
+      "import": "./dist/cli/index.js",
+      "types": "./dist/cli/index.d.ts"
     },
-    "files": [
-        "/dist"
-    ],
-    "scripts": {
-        "clean": "shx rm -rf dist",
-        "prepack": "cross-env NODE_ENV=production pnpm run build",
-        "build": "pnpm clean && rollup -c",
-        "lint": "prettier -c src/** && eslint 'src/**/*.ts'",
-        "lint:fix": "prettier -w src/** && eslint 'src/**/*.ts' --fix",
-        "test": "vitest run",
-        "test:watch": "vitest",
-        "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit-core.xml",
-        "tsc": "tsc --noEmit"
+    "./framework": {
+      "import": "./dist/framework/index.js",
+      "types": "./dist/framework/index.d.ts"
     },
-    "eslintConfig": {
-        "extends": [
-            "../../.eslintrc.cjs"
-        ]
-    },
-    "dependencies": {
-        "zod": "^3.11.6",
-        "pino": "^7.8.0",
-        "pino-pretty": "^7.5.1",
-        "pino-abstract-transport": "^0.5.0",
-        "@gestaltjs/renderer": "0.7.3"
-    },
-    "devDependencies": {
-        "@iarna/toml": "2.2.5",
-        "@types/pino": "7.0.5",
-        "@types/shelljs": "0.8.11",
-        "case-anything": "2.1.10",
-        "fastify": "3.27.4",
-        "find-up": "6.3.0",
-        "fs-extra": "10.0.1",
-        "noop-stream": "1.0.0",
-        "pathe": "0.2.0",
-        "picocolors": "1.0.0",
-        "shelljs": "0.8.5",
-        "tempy": "2.0.0",
-        "terminal-link": "3.0.0",
-        "vite": "2.9.1",
-        "zod": "3.14.4",
-        "handlebars": "4.7.7"
-    },
-    "engine-strict": true,
-    "engines": {
-        "node": "^14.13.1 || >=16.0.0 || >=17.0.0"
-    },
-    "os": [
-        "darwin",
-        "linux",
-        "win32"
+    "./shared": {
+      "import": "./dist/shared/index.js",
+      "types": "./dist/shared/index.d.ts"
+    }
+  },
+  "files": [
+    "/dist"
+  ],
+  "scripts": {
+    "clean": "shx rm -rf dist",
+    "prepack": "cross-env NODE_ENV=production pnpm run build",
+    "build": "pnpm clean && rollup -c",
+    "lint": "prettier -c src/** && eslint 'src/**/*.ts'",
+    "lint:fix": "prettier -w src/** && eslint 'src/**/*.ts' --fix",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit-core.xml",
+    "tsc": "tsc --noEmit"
+  },
+  "eslintConfig": {
+    "extends": [
+      "../../.eslintrc.cjs"
     ]
+  },
+  "dependencies": {
+    "zod": "^3.11.6",
+    "pino": "^7.8.0",
+    "pino-pretty": "^7.5.1",
+    "pino-abstract-transport": "^0.5.0",
+    "@gestaltjs/vue-gestalt-renderer": "0.7.3",
+    "@gestaltjs/renderer": "0.7.3"
+  },
+  "devDependencies": {
+    "@iarna/toml": "2.2.5",
+    "@types/pino": "7.0.5",
+    "@types/shelljs": "0.8.11",
+    "case-anything": "2.1.10",
+    "fastify": "3.27.4",
+    "find-up": "6.3.0",
+    "fs-extra": "10.0.1",
+    "noop-stream": "1.0.0",
+    "pathe": "0.2.0",
+    "picocolors": "1.0.0",
+    "shelljs": "0.8.5",
+    "tempy": "2.0.0",
+    "terminal-link": "3.0.0",
+    "vite": "2.9.1",
+    "zod": "3.14.3",
+    "handlebars": "4.7.7"
+  },
+  "engine-strict": true,
+  "engines": {
+    "node": "^14.13.1 || >=16.0.0 || >=17.0.0"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ]
 }

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "@gestaltjs/core",
+    "name": "@gestaltjs/renderer",
     "version": "0.7.3",
     "private": false,
-    "description": "Set of Getalt tools and models that are shared across all the features",
+    "description": "Models and convenient utilities for defining Gestalr renderers",
     "keywords": [
         "gestalt",
         "gestaltjs",
@@ -11,17 +11,9 @@
     "license": "MIT",
     "type": "module",
     "exports": {
-        "./cli": {
-            "import": "./dist/cli/index.js",
-            "types": "./dist/cli/index.d.ts"
-        },
-        "./framework": {
-            "import": "./dist/framework/index.js",
-            "types": "./dist/framework/index.d.ts"
-        },
-        "./shared": {
-            "import": "./dist/shared/index.js",
-            "types": "./dist/shared/index.d.ts"
+        ".": {
+            "import": "./dist/index.js",
+            "types": "./dist/index.d.ts"
         }
     },
     "files": [
@@ -44,29 +36,11 @@
         ]
     },
     "dependencies": {
-        "zod": "^3.11.6",
         "pino": "^7.8.0",
         "pino-pretty": "^7.5.1",
-        "pino-abstract-transport": "^0.5.0",
-        "@gestaltjs/renderer": "0.7.3"
+        "pino-abstract-transport": "^0.5.0"
     },
     "devDependencies": {
-        "@iarna/toml": "2.2.5",
-        "@types/pino": "7.0.5",
-        "@types/shelljs": "0.8.11",
-        "case-anything": "2.1.10",
-        "fastify": "3.27.4",
-        "find-up": "6.3.0",
-        "fs-extra": "10.0.1",
-        "noop-stream": "1.0.0",
-        "pathe": "0.2.0",
-        "picocolors": "1.0.0",
-        "shelljs": "0.8.5",
-        "tempy": "2.0.0",
-        "terminal-link": "3.0.0",
-        "vite": "2.9.1",
-        "zod": "3.14.4",
-        "handlebars": "4.7.7"
     },
     "engine-strict": true,
     "engines": {

--- a/packages/renderer/rollup.config.js
+++ b/packages/renderer/rollup.config.js
@@ -1,0 +1,24 @@
+import path from 'pathe'
+import dts from 'rollup-plugin-dts'
+
+import { external, plugins, distDir } from '../../configurations/rollup.config'
+
+const configuration = async () => {
+  const rendererExternal = [...(await external(__dirname))]
+  return [
+    {
+      input: path.join(__dirname, "src/index.ts"),
+      output: [
+        {
+          file: path.join(distDir(__dirname),"index.js"),
+          format: 'esm',
+          exports: 'auto',
+        },
+      ],
+      plugins: plugins(__dirname),
+      external: rendererExternal,
+    }
+  ]
+}
+
+export default configuration

--- a/packages/renderer/src/index.test.ts
+++ b/packages/renderer/src/index.test.ts
@@ -1,0 +1,5 @@
+import { it, expect } from 'vitest'
+
+it('works', () => {
+  expect(true).toBe(true)
+})

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1,0 +1,26 @@
+import type { Renderer } from './renderer'
+
+export { Renderer }
+
+type RendererArg = Renderer | (() => Promise<Renderer>) | (() => Renderer)
+
+/**
+ * A utility function to define new renderers. Since the function has its argument and
+ * return value typed, when using it from the renderer default module, editors will
+ * offer a better editing experience with syntax highlighting, validation, documentation,
+ * and auto-completion.
+ *
+ * Alternatively, renderers can use the '@type' annotation:
+ *   @type {import('@gestaltjs/renderer').Renderer}
+ *   const config = {...}
+ *
+ * @param renderer {Renderer | () => Promise<Renderer> | () => Renderer} Define a new renderer.
+ * @returns A promise that resolves with the renderer.
+ */
+export async function defineRenderer(renderer: RendererArg): Promise<Renderer> {
+  if (typeof renderer === 'function') {
+    return await renderer
+  } else {
+    return renderer
+  }
+}

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -2,7 +2,7 @@ import type { Renderer } from './renderer'
 
 export { Renderer }
 
-type RendererArg = Renderer | (() => Promise<Renderer>) | (() => Renderer)
+type RendererExport = Renderer | (() => Promise<Renderer>) | (() => Renderer)
 
 /**
  * A utility function to define new renderers. Since the function has its argument and
@@ -17,10 +17,6 @@ type RendererArg = Renderer | (() => Promise<Renderer>) | (() => Renderer)
  * @param renderer {Renderer | () => Promise<Renderer> | () => Renderer} Define a new renderer.
  * @returns A promise that resolves with the renderer.
  */
-export async function defineRenderer(renderer: RendererArg): Promise<Renderer> {
-  if (typeof renderer === 'function') {
-    return await renderer
-  } else {
-    return renderer
-  }
+export function defineRenderer(renderer: RendererExport): RendererExport {
+  return renderer
 }

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -1,0 +1,3 @@
+export type Renderer = {
+  dependencies: { [key: string]: string }
+}

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./dist"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "baseUrl": "src",
+  }
+}

--- a/packages/renderer/vitest.config.ts
+++ b/packages/renderer/vitest.config.ts
@@ -1,0 +1,3 @@
+import config from '../../configurations/vitest.config'
+
+export default config(__dirname)

--- a/packages/vue-renderer/package.json
+++ b/packages/vue-renderer/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@gestaltjs/renderer",
+  "name": "@gestaltjs/vue-gestalt-renderer",
   "version": "0.7.3",
   "private": false,
-  "description": "Models and convenient utilities for defining Gestalr renderers",
+  "description": "Gestalt's default Vue renderer",
   "keywords": [
     "gestalt",
     "gestaltjs",
@@ -36,7 +36,9 @@
     ]
   },
   "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "@gestaltjs/renderer": "0.7.3"
+  },
   "engine-strict": true,
   "engines": {
     "node": "^14.13.1 || >=16.0.0 || >=17.0.0"

--- a/packages/vue-renderer/rollup.config.js
+++ b/packages/vue-renderer/rollup.config.js
@@ -1,0 +1,24 @@
+import path from 'pathe'
+import dts from 'rollup-plugin-dts'
+
+import { external, plugins, distDir } from '../../configurations/rollup.config'
+
+const configuration = async () => {
+  const rendererExternal = [...(await external(__dirname))]
+  return [
+    {
+      input: path.join(__dirname, "src/index.ts"),
+      output: [
+        {
+          file: path.join(distDir(__dirname),"index.js"),
+          format: 'esm',
+          exports: 'auto',
+        },
+      ],
+      plugins: plugins(__dirname),
+      external: rendererExternal,
+    }
+  ]
+}
+
+export default configuration

--- a/packages/vue-renderer/src/index.test.ts
+++ b/packages/vue-renderer/src/index.test.ts
@@ -1,0 +1,5 @@
+import { it, expect } from 'vitest'
+
+it('works', () => {
+  expect(true).toBe(true)
+})

--- a/packages/vue-renderer/src/index.ts
+++ b/packages/vue-renderer/src/index.ts
@@ -1,22 +1,7 @@
-import type { Renderer } from './renderer'
+import { defineRenderer } from '@gestaltjs/renderer'
 
-export { Renderer }
-
-type RendererExport = Renderer | (() => Promise<Renderer>) | (() => Renderer)
-
-/**
- * A utility function to define new renderers. Since the function has its argument and
- * return value typed, when using it from the renderer default module, editors will
- * offer a better editing experience with syntax highlighting, validation, documentation,
- * and auto-completion.
- *
- * Alternatively, renderers can use the '@type' annotation:
- *   @type {import('@gestaltjs/renderer').Renderer}
- *   const config = {...}
- *
- * @param renderer {Renderer | () => Promise<Renderer> | () => Renderer} Define a new renderer.
- * @returns A promise that resolves with the renderer.
- */
-export function defineRenderer(renderer: RendererExport): RendererExport {
-  return renderer
-}
+export default defineRenderer({
+  dependencies: {
+    vue: '1.2.3',
+  },
+})

--- a/packages/vue-renderer/src/index.ts
+++ b/packages/vue-renderer/src/index.ts
@@ -1,0 +1,22 @@
+import type { Renderer } from './renderer'
+
+export { Renderer }
+
+type RendererExport = Renderer | (() => Promise<Renderer>) | (() => Renderer)
+
+/**
+ * A utility function to define new renderers. Since the function has its argument and
+ * return value typed, when using it from the renderer default module, editors will
+ * offer a better editing experience with syntax highlighting, validation, documentation,
+ * and auto-completion.
+ *
+ * Alternatively, renderers can use the '@type' annotation:
+ *   @type {import('@gestaltjs/renderer').Renderer}
+ *   const config = {...}
+ *
+ * @param renderer {Renderer | () => Promise<Renderer> | () => Renderer} Define a new renderer.
+ * @returns A promise that resolves with the renderer.
+ */
+export function defineRenderer(renderer: RendererExport): RendererExport {
+  return renderer
+}

--- a/packages/vue-renderer/src/renderer.ts
+++ b/packages/vue-renderer/src/renderer.ts
@@ -1,3 +1,0 @@
-export type Renderer = {
-  dependencies: { [key: string]: string }
-}

--- a/packages/vue-renderer/src/renderer.ts
+++ b/packages/vue-renderer/src/renderer.ts
@@ -1,0 +1,3 @@
+export type Renderer = {
+  dependencies: { [key: string]: string }
+}

--- a/packages/vue-renderer/tsconfig.json
+++ b/packages/vue-renderer/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./dist"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "baseUrl": "src",
+  }
+}

--- a/packages/vue-renderer/vitest.config.ts
+++ b/packages/vue-renderer/vitest.config.ts
@@ -1,0 +1,3 @@
+import config from '../../configurations/vitest.config'
+
+export default config(__dirname)

--- a/packages/website/docs/.vitepress/config.js
+++ b/packages/website/docs/.vitepress/config.js
@@ -106,6 +106,7 @@ function getContributorsSidebar() {
         { text: 'Get started', link: '/contributors/get-started' },
         { text: 'Architecture', link: '/contributors/architecture' },
         { text: 'Principles', link: '/contributors/principles' },
+        { text: 'Renderers', link: '/contributors/renderers' },
         { text: 'ESLint rules', link: '/contributors/eslint-rules' },
         { text: 'Error handling', link: '/contributors/errors' },
         { text: 'Logging', link: '/contributors/logging' },

--- a/packages/website/docs/contributors/architecture.md
+++ b/packages/website/docs/contributors/architecture.md
@@ -21,3 +21,4 @@ and contribute to an area of the project without having to familiarize ourselves
 | `@gestaltjs/check` | It contains utilities for checking the code | `TypeChecker` class |
 | `@gestaltjs/dev` | It contains utilities for serving the app locally and in production | `Server` class |
 | `@gestaltjs/core` | It contains utilities and models that are shared across all the features above it | `App` model |
+| `@gestaltjs/renderer` | It contains models and utilities to create new renderers | `Renderer` model and `defineRenderer` function |

--- a/packages/website/docs/contributors/renderers.md
+++ b/packages/website/docs/contributors/renderers.md
@@ -1,0 +1,58 @@
+# Renderers
+
+Although Gestalt defaults to [Vue](https://vuejs.org/) for its declarative [UI](https://en.wikipedia.org/wiki/User_interface) layer,
+it supports other UI technologies (e.g., [React](https://reactjs.org/)) through renderers.
+A renderer instructs Gestalt on how to transpile templates (e.g. JSX files) by providing [Vite plugins](https://vitejs.dev/plugins/).
+Moreover, it offers routing components and the logic for rendering UI client and server-side.
+
+### Implementing a new renderer
+
+Renderers are distributed as NPM packages that follow the naming convention `{ui}-gestalt-renderer` or `@{org}/{ui}-gestalt-renderer`.
+For example, `@gestaltjs/react-gestalt-renderer` in the case of React.
+If a project has a renderer as a dependency, Gestalt will use it by default.
+
+The NPM package has to be pure [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), and the main module has to export a default object representing the renderer.
+The example below shows how to use `type` and `exports` attributes in the `package.json` to indicate Node that the package is ESM and what are its exported modules:
+
+```json
+// package.json
+{
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/index.js",
+            "types": "./dist/index.d.ts"
+        },
+    },
+    "devDependency": {
+        "@gestaltjs/renderer": "..."
+    }
+}
+```
+
+Gestalt expects a default export with the object representing the renderer:
+
+```ts
+// @gestaltjs/react-gestalt-renderer
+// src/index.ts
+import { defineRenderer } from "@gestaltjs/renderer"
+import clientRender from "./client"
+import serverRender from "./server"
+import react from '@vitejs/plugin-react'
+
+export default defineRenderer({
+  dependencies: {
+    "react": "~> 17.0.0"
+  },
+  vite: {
+    plugins: [
+      react()
+    ]
+  },
+  render: {
+    client: clientRender
+    server: serverRender
+  },
+  components: {}
+})
+```

--- a/packages/website/docs/contributors/renderers.md
+++ b/packages/website/docs/contributors/renderers.md
@@ -12,7 +12,7 @@ For example, `@gestaltjs/react-gestalt-renderer` in the case of React.
 If a project has a renderer as a dependency, Gestalt will use it by default.
 
 The NPM package has to be pure [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules), and the main module has to export a default object representing the renderer.
-The example below shows how to use `type` and `exports` attributes in the `package.json` to indicate Node that the package is ESM and what are its exported modules:
+The example below shows how to use `type` and `exports` attributes in the `package.json` to indicate tos Node that the package is ESM and what are its exported modules:
 
 ```json
 // package.json

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,14 +248,7 @@ importers:
       '@oclif/plugin-plugins': 2.1.0
 
   packages/renderer:
-    specifiers:
-      pino: ^7.8.0
-      pino-abstract-transport: ^0.5.0
-      pino-pretty: ^7.5.1
-    dependencies:
-      pino: 7.8.0
-      pino-abstract-transport: 0.5.0
-      pino-pretty: 7.5.1
+    specifiers: {}
 
   packages/test:
     specifiers:
@@ -270,6 +263,12 @@ importers:
       tempy: 2.0.0
     devDependencies:
       tempy: 2.0.0
+
+  packages/vue-renderer:
+    specifiers:
+      '@gestaltjs/renderer': 0.7.3
+    devDependencies:
+      '@gestaltjs/renderer': link:../renderer
 
   packages/website:
     specifiers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,7 @@ importers:
 
   packages/core:
     specifiers:
+      '@gestaltjs/renderer': 0.7.3
       '@iarna/toml': 2.2.5
       '@types/pino': 7.0.5
       '@types/shelljs': 0.8.11
@@ -153,6 +154,7 @@ importers:
       vite: 2.9.1
       zod: ^3.11.6
     dependencies:
+      '@gestaltjs/renderer': link:../renderer
       pino: 7.8.0
       pino-abstract-transport: 0.5.0
       pino-pretty: 7.5.1
@@ -244,6 +246,16 @@ importers:
       '@oclif/core': 1.5.2
       '@oclif/plugin-help': 5.1.11
       '@oclif/plugin-plugins': 2.1.0
+
+  packages/renderer:
+    specifiers:
+      pino: ^7.8.0
+      pino-abstract-transport: ^0.5.0
+      pino-pretty: ^7.5.1
+    dependencies:
+      pino: 7.8.0
+      pino-abstract-transport: 0.5.0
+      pino-pretty: 7.5.1
 
   packages/test:
     specifiers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,7 @@ importers:
   packages/core:
     specifiers:
       '@gestaltjs/renderer': 0.7.3
+      '@gestaltjs/vue-gestalt-renderer': 0.7.3
       '@iarna/toml': 2.2.5
       '@types/pino': 7.0.5
       '@types/shelljs': 0.8.11
@@ -155,6 +156,7 @@ importers:
       zod: ^3.11.6
     dependencies:
       '@gestaltjs/renderer': link:../renderer
+      '@gestaltjs/vue-gestalt-renderer': link:../vue-renderer
       pino: 7.8.0
       pino-abstract-transport: 0.5.0
       pino-pretty: 7.5.1

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,6 +19,7 @@
       "@gestaltjs/core/framework": ["../../core/src/framework/index.ts"],
       "@gestaltjs/core/cli": ["../../core/src/cli/index.ts"],
       "@gestaltjs/testing": ["../../testing/src/index.ts"],
+      "@gestaltjs/renderer": ["../../renderer/src/index.ts"],
       "$*": [ "./*" ]
     },
     "types": ["vitest/globals"]


### PR DESCRIPTION
## What?
I'm introducing a new building block, **renderers**, that gives us and external developers an API to replace Vue as the default UI layer. A renderer instructs Gestalt on how to transpile templates, and provides routing components, client and server render functions, and dependency requirements that will be checked against the projects.

## Why?

Although Vue is the UI technology that aligns best with Gestalt's principles and ideas, it might be limiting for developers or teams that might have got familiar with other technologies like React or Svelte. Those users might want to use Gestalt to benefit from its conventions and built-in batteries, but they won't be able to do it due to our strong opinion on the UI layer.

## How?
- Created a new package, `@gestaltjs/renderer` that exports models and convenient functions to create renderers.
- Created a new package, `@gestaltjs/vue-gestalt-renderer` where we can implement the default Vue renderer.
- Started documenting the idea behind renderers and pseudo-coded what its interface might look like (subject to change).

## Screenshots (optional)

<img width="777" alt="image" src="https://user-images.githubusercontent.com/663605/161580845-ffc1c090-309f-45f6-8338-42340989d67f.png">

