### PR TITLE
Take a different approach to exporting modules

### DIFF
--- a/configurations/rollup.config.js
+++ b/configurations/rollup.config.js
@@ -12,6 +12,10 @@ export const distDir = (packageDir) => {
 export const aliases = (packageDir) => {
   return [
     {
+      find: '@gestaltjs/core/node/path',
+      replacement: path.join(packageDir, '../core/src/node/path.public.ts'),
+    },
+    {
       find: '@gestaltjs/plugins',
       replacement: path.join(packageDir, '../plugins/src/runtime/index.ts'),
     },

--- a/configurations/rollup.config.js
+++ b/configurations/rollup.config.js
@@ -13,7 +13,7 @@ export const aliases = (packageDir) => {
   return [
     {
       find: '@gestaltjs/core/node/path',
-      replacement: path.join(packageDir, '../core/src/node/path.public.ts'),
+      replacement: path.join(packageDir, '../core/src/node/path.ts'),
     },
     {
       find: '@gestaltjs/plugins',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,8 +12,8 @@
   "type": "module",
   "exports": {
     "./node/path": {
-      "node": "./dist/node/path.public.js",
-      "types": "./dist/node/path.public.d.ts"
+      "node": "./dist/node/path.js",
+      "types": "./dist/node/path.d.ts"
     },
     "./cli": {
       "import": "./dist/cli/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,10 @@
   "license": "MIT",
   "type": "module",
   "exports": {
+    "./node/path": {
+      "node": "./dist/node/path.public.js",
+      "types": "./dist/node/path.public.d.ts"
+    },
     "./cli": {
       "import": "./dist/cli/index.js",
       "types": "./dist/cli/index.d.ts"

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -6,7 +6,7 @@ import { external, plugins, distDir } from '../../configurations/rollup.config'
 const configuration = async () => {
   const coreExternal = [...(await external(__dirname))]
   const publicFiles = ['src/runtime/index.ts', 'src/shared/index.ts']
-  const nodeFiles = await fg('src/node/*.public.ts', {
+  const nodeFiles = await fg('src/node/*.ts', {
     ignore: 'src/node/*.test.ts',
   })
 

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -1,11 +1,14 @@
 import * as path from 'pathe'
 import dts from 'rollup-plugin-dts'
-
+import fg from 'fast-glob'
 import { external, plugins, distDir } from '../../configurations/rollup.config'
 
 const configuration = async () => {
   const coreExternal = [...(await external(__dirname))]
   const publicFiles = ['src/runtime/index.ts', 'src/shared/index.ts']
+  const nodeFiles = await fg('src/node/*.public.ts', {
+    ignore: 'src/node/*.test.ts',
+  })
 
   const cliFiles = [
     'src/cli/index.ts',
@@ -14,6 +17,31 @@ const configuration = async () => {
   ]
 
   return [
+    {
+      input: nodeFiles,
+      output: [
+        {
+          dir: path.join(distDir(__dirname), 'node'),
+          format: 'esm',
+          exports: 'auto',
+          sourcemap: true,
+        },
+      ],
+      plugins: plugins(__dirname),
+      external: coreExternal,
+    },
+    {
+      input: nodeFiles,
+      output: [
+        {
+          dir: path.join(distDir(__dirname), 'node'),
+          format: 'esm',
+          sourcemap: 'inline',
+        },
+      ],
+      plugins: [dts()],
+      external: [...(await external(__dirname))],
+    },
     ...cliFiles.map((filePath) => {
       return {
         input: path.join(__dirname, filePath),

--- a/packages/core/src/cli/command.ts
+++ b/packages/core/src/cli/command.ts
@@ -1,5 +1,5 @@
 import { Command, Flags } from '@oclif/core'
-import { resolve as pathResolve } from '../node/path.public'
+import { resolve as pathResolve } from '../node/path'
 
 // eslint-disable-next-line import/no-default-export
 export default abstract class extends Command {

--- a/packages/core/src/cli/command.ts
+++ b/packages/core/src/cli/command.ts
@@ -1,5 +1,5 @@
 import { Command, Flags } from '@oclif/core'
-import { resolve as pathResolve } from '../shared/path'
+import { resolve as pathResolve } from '../node/path.public'
 
 // eslint-disable-next-line import/no-default-export
 export default abstract class extends Command {

--- a/packages/core/src/cli/command.ts
+++ b/packages/core/src/cli/command.ts
@@ -1,5 +1,5 @@
 import { Command, Flags } from '@oclif/core'
-import { resolve as pathResolve } from '../node/path'
+import { resolvePath } from '../node/path'
 
 // eslint-disable-next-line import/no-default-export
 export default abstract class extends Command {
@@ -36,7 +36,7 @@ export default abstract class extends Command {
       char: 'p',
       env: 'GESTALT_PATH',
       default: process.cwd(),
-      parse: async (input) => pathResolve(input),
+      parse: async (input) => resolvePath(input),
       description: 'The path to the directory from where the command will run.',
       required: false,
     }),

--- a/packages/core/src/cli/eslint.test.ts
+++ b/packages/core/src/cli/eslint.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from 'vitest'
 import { exec } from './system'
-import { findPathUp, dirname } from '../node/path.public'
+import { findPathUp, parentDirectory } from '../node/path'
 import { run, ESLintNotFoundError } from './eslint'
 
 vi.mock('./system')
@@ -12,7 +12,7 @@ describe('run', () => {
     const eslintPath = '/test/eslint'
     const eslintTSDirectory = '/gestalt/eslint'
     vi.mocked(findPathUp).mockResolvedValue(eslintPath)
-    vi.mocked(dirname).mockReturnValue(eslintTSDirectory)
+    vi.mocked(parentDirectory).mockReturnValue(eslintTSDirectory)
     const args = ['foo']
     const cwd = '/project'
 
@@ -33,7 +33,7 @@ describe('run', () => {
     // Given
     const eslintTSDirectory = '/gestalt/eslint'
     vi.mocked(findPathUp).mockResolvedValue(undefined)
-    vi.mocked(dirname).mockReturnValue(eslintTSDirectory)
+    vi.mocked(parentDirectory).mockReturnValue(eslintTSDirectory)
     const args = ['foo']
     const cwd = '/project'
 

--- a/packages/core/src/cli/eslint.test.ts
+++ b/packages/core/src/cli/eslint.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from 'vitest'
 import { exec } from './system'
-import { findUp, dirname } from '../node/path.public'
+import { findPathUp, dirname } from '../node/path.public'
 import { run, ESLintNotFoundError } from './eslint'
 
 vi.mock('./system')
@@ -11,7 +11,7 @@ describe('run', () => {
     // Given
     const eslintPath = '/test/eslint'
     const eslintTSDirectory = '/gestalt/eslint'
-    vi.mocked(findUp).mockResolvedValue(eslintPath)
+    vi.mocked(findPathUp).mockResolvedValue(eslintPath)
     vi.mocked(dirname).mockReturnValue(eslintTSDirectory)
     const args = ['foo']
     const cwd = '/project'
@@ -20,7 +20,7 @@ describe('run', () => {
     await run(args, cwd)
 
     // Then
-    expect(findUp).toHaveBeenCalledWith('node_modules/.bin/eslint', {
+    expect(findPathUp).toHaveBeenCalledWith('node_modules/.bin/eslint', {
       cwd: eslintTSDirectory,
     })
     expect(exec).toHaveBeenCalledWith(eslintPath, args, {
@@ -32,7 +32,7 @@ describe('run', () => {
   test('aborts when ESLint cannot be found', async () => {
     // Given
     const eslintTSDirectory = '/gestalt/eslint'
-    vi.mocked(findUp).mockResolvedValue(undefined)
+    vi.mocked(findPathUp).mockResolvedValue(undefined)
     vi.mocked(dirname).mockReturnValue(eslintTSDirectory)
     const args = ['foo']
     const cwd = '/project'

--- a/packages/core/src/cli/eslint.test.ts
+++ b/packages/core/src/cli/eslint.test.ts
@@ -4,7 +4,7 @@ import { findUp, dirname } from '../node/path.public'
 import { run, ESLintNotFoundError } from './eslint'
 
 vi.mock('./system')
-vi.mock('../shared/path')
+vi.mock('../node/path.public')
 
 describe('run', () => {
   test('runs eslint', async () => {

--- a/packages/core/src/cli/eslint.test.ts
+++ b/packages/core/src/cli/eslint.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from 'vitest'
 import { exec } from './system'
-import { findUp, dirname } from '../shared/path'
+import { findUp, dirname } from '../node/path.public'
 import { run, ESLintNotFoundError } from './eslint'
 
 vi.mock('./system')

--- a/packages/core/src/cli/eslint.test.ts
+++ b/packages/core/src/cli/eslint.test.ts
@@ -4,7 +4,7 @@ import { findPathUp, parentDirectory } from '../node/path'
 import { run, ESLintNotFoundError } from './eslint'
 
 vi.mock('./system')
-vi.mock('../node/path.public')
+vi.mock('../node/path')
 
 describe('run', () => {
   test('runs eslint', async () => {

--- a/packages/core/src/cli/eslint.ts
+++ b/packages/core/src/cli/eslint.ts
@@ -1,6 +1,6 @@
 import { Abort } from '../shared/error'
 import { exec } from './system'
-import { findUp, dirname } from '../node/path.public'
+import { findPathUp, dirname } from '../node/path.public'
 import { fileURLToPath } from 'url'
 
 export const ESLintNotFoundError = () => {
@@ -11,7 +11,7 @@ export const ESLintNotFoundError = () => {
 
 export async function run(args: string[], cwd: string) {
   const __dirname = dirname(fileURLToPath(import.meta.url))
-  const eslintPath = await findUp('node_modules/.bin/eslint', {
+  const eslintPath = await findPathUp('node_modules/.bin/eslint', {
     cwd: __dirname,
   })
   if (!eslintPath) {

--- a/packages/core/src/cli/eslint.ts
+++ b/packages/core/src/cli/eslint.ts
@@ -1,6 +1,6 @@
 import { Abort } from '../shared/error'
 import { exec } from './system'
-import { findUp, dirname } from '../shared/path'
+import { findUp, dirname } from '../node/path.public'
 import { fileURLToPath } from 'url'
 
 export const ESLintNotFoundError = () => {

--- a/packages/core/src/cli/eslint.ts
+++ b/packages/core/src/cli/eslint.ts
@@ -1,6 +1,6 @@
 import { Abort } from '../shared/error'
 import { exec } from './system'
-import { findPathUp, dirname } from '../node/path.public'
+import { findPathUp, parentDirectory } from '../node/path'
 import { fileURLToPath } from 'url'
 
 export const ESLintNotFoundError = () => {
@@ -10,7 +10,7 @@ export const ESLintNotFoundError = () => {
 }
 
 export async function run(args: string[], cwd: string) {
-  const __dirname = dirname(fileURLToPath(import.meta.url))
+  const __dirname = parentDirectory(fileURLToPath(import.meta.url))
   const eslintPath = await findPathUp('node_modules/.bin/eslint', {
     cwd: __dirname,
   })

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,4 +1,4 @@
-export * as path from '../shared/path'
+export * as path from '../node/path.public'
 export * as system from './system'
 export * as error from '../shared/error'
 export * as logger from './logger'

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,4 +1,4 @@
-export * as path from '../node/path.public'
+export * as path from '../node/path'
 export * as system from './system'
 export * as error from '../shared/error'
 export * as logger from './logger'

--- a/packages/core/src/cli/logger.ts
+++ b/packages/core/src/cli/logger.ts
@@ -6,7 +6,7 @@ import terminalLink from 'terminal-link'
 import { isRunningTests } from './environment'
 import { LoggerContentToken, LoggerContentType } from './logger/content'
 import { LoggerTarget, NoopLoggerTarget } from './logger/target'
-import { relativizePath } from '../node/path.public'
+import { relativizePath } from '../node/path'
 
 /**
  * We cache the loggers to ensure we only have an

--- a/packages/core/src/cli/logger.ts
+++ b/packages/core/src/cli/logger.ts
@@ -6,7 +6,7 @@ import terminalLink from 'terminal-link'
 import { isRunningTests } from './environment'
 import { LoggerContentToken, LoggerContentType } from './logger/content'
 import { LoggerTarget, NoopLoggerTarget } from './logger/target'
-import { relativize } from '../node/path.public'
+import { relativizePath } from '../node/path.public'
 
 /**
  * We cache the loggers to ensure we only have an
@@ -219,7 +219,7 @@ export function content(
       const enumToken = token as LoggerContentToken
       switch (enumToken.type) {
         case LoggerContentType.Path:
-          output += formatGray(relativize(enumToken.value))
+          output += formatGray(relativizePath(enumToken.value))
           break
         case LoggerContentType.File:
           output += formatGray(enumToken.value)

--- a/packages/core/src/cli/logger.ts
+++ b/packages/core/src/cli/logger.ts
@@ -6,7 +6,7 @@ import terminalLink from 'terminal-link'
 import { isRunningTests } from './environment'
 import { LoggerContentToken, LoggerContentType } from './logger/content'
 import { LoggerTarget, NoopLoggerTarget } from './logger/target'
-import { relativize } from '../shared/path'
+import { relativize } from '../node/path.public'
 
 /**
  * We cache the loggers to ensure we only have an

--- a/packages/core/src/cli/npm.test.ts
+++ b/packages/core/src/cli/npm.test.ts
@@ -1,5 +1,5 @@
 import { addDependencies, inferDependencyManager } from './npm'
-import { join as pathJoin } from '../shared/path'
+import { join as pathJoin } from '../node/path.public'
 import { writeFile, makeDirectory } from '../shared/fs'
 import { describe, test, expect, vi } from 'vitest'
 import { exec } from './system'

--- a/packages/core/src/cli/npm.test.ts
+++ b/packages/core/src/cli/npm.test.ts
@@ -1,5 +1,5 @@
 import { addDependencies, inferDependencyManager } from './npm'
-import { joinPath } from '../node/path.public'
+import { joinPath } from '../node/path'
 import { writeFile, makeDirectory } from '../shared/fs'
 import { describe, test, expect, vi } from 'vitest'
 import { exec } from './system'

--- a/packages/core/src/cli/npm.test.ts
+++ b/packages/core/src/cli/npm.test.ts
@@ -1,5 +1,5 @@
 import { addDependencies, inferDependencyManager } from './npm'
-import { join as pathJoin } from '../node/path.public'
+import { joinPath } from '../node/path.public'
 import { writeFile, makeDirectory } from '../shared/fs'
 import { describe, test, expect, vi } from 'vitest'
 import { exec } from './system'
@@ -11,7 +11,7 @@ describe('addDependencies', () => {
   test('runs the right command when npm and dev dependencies', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const packageJsonPath = pathJoin(tmpDir, 'package.json')
+      const packageJsonPath = joinPath(tmpDir, 'package.json')
       await writeFile(packageJsonPath, JSON.stringify({}))
 
       // When
@@ -34,7 +34,7 @@ describe('addDependencies', () => {
   test('runs the right command when npm and production dependencies', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const packageJsonPath = pathJoin(tmpDir, 'package.json')
+      const packageJsonPath = joinPath(tmpDir, 'package.json')
       await writeFile(packageJsonPath, JSON.stringify({}))
 
       // When
@@ -57,7 +57,7 @@ describe('addDependencies', () => {
   test('runs the right command when npm and peer dependencies', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const packageJsonPath = pathJoin(tmpDir, 'package.json')
+      const packageJsonPath = joinPath(tmpDir, 'package.json')
       await writeFile(packageJsonPath, JSON.stringify({}))
 
       // When
@@ -80,7 +80,7 @@ describe('addDependencies', () => {
   test('runs the right command when yarn and dev dependencies', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const packageJsonPath = pathJoin(tmpDir, 'package.json')
+      const packageJsonPath = joinPath(tmpDir, 'package.json')
       await writeFile(packageJsonPath, JSON.stringify({}))
 
       // When
@@ -103,7 +103,7 @@ describe('addDependencies', () => {
   test('runs the right command when yarn and prod dependencies', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const packageJsonPath = pathJoin(tmpDir, 'package.json')
+      const packageJsonPath = joinPath(tmpDir, 'package.json')
       await writeFile(packageJsonPath, JSON.stringify({}))
 
       // When
@@ -126,7 +126,7 @@ describe('addDependencies', () => {
   test('runs the right command when yarn and peer dependencies', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const packageJsonPath = pathJoin(tmpDir, 'package.json')
+      const packageJsonPath = joinPath(tmpDir, 'package.json')
       await writeFile(packageJsonPath, JSON.stringify({}))
 
       // When
@@ -149,7 +149,7 @@ describe('addDependencies', () => {
   test('runs the right command when pnpm and dev dependencies', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const packageJsonPath = pathJoin(tmpDir, 'package.json')
+      const packageJsonPath = joinPath(tmpDir, 'package.json')
       await writeFile(packageJsonPath, JSON.stringify({}))
 
       // When
@@ -172,7 +172,7 @@ describe('addDependencies', () => {
   test('runs the right command when pnpm and peer dependencies', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const packageJsonPath = pathJoin(tmpDir, 'package.json')
+      const packageJsonPath = joinPath(tmpDir, 'package.json')
       await writeFile(packageJsonPath, JSON.stringify({}))
 
       // When
@@ -197,8 +197,8 @@ describe('inferDependencyManager', () => {
   test('returns yarn when it finds a yarn.lock', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const lockfilePath = pathJoin(tmpDir, 'yarn.lock')
-      const nestedDirectory = pathJoin(tmpDir, 'a/b/c')
+      const lockfilePath = joinPath(tmpDir, 'yarn.lock')
+      const nestedDirectory = joinPath(tmpDir, 'a/b/c')
       await makeDirectory(nestedDirectory)
       await writeFile(lockfilePath, '')
 
@@ -213,8 +213,8 @@ describe('inferDependencyManager', () => {
   test('returns pnpm when it finds a pnpm-lock.yaml', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const lockfilePath = pathJoin(tmpDir, 'pnpm-lock.yaml')
-      const nestedDirectory = pathJoin(tmpDir, 'a/b/c')
+      const lockfilePath = joinPath(tmpDir, 'pnpm-lock.yaml')
+      const nestedDirectory = joinPath(tmpDir, 'a/b/c')
       await makeDirectory(nestedDirectory)
       await writeFile(lockfilePath, '')
 
@@ -229,7 +229,7 @@ describe('inferDependencyManager', () => {
   test('returns npm by default', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const nestedDirectory = pathJoin(tmpDir, 'a/b/c')
+      const nestedDirectory = joinPath(tmpDir, 'a/b/c')
       await makeDirectory(nestedDirectory)
 
       // When

--- a/packages/core/src/cli/npm.ts
+++ b/packages/core/src/cli/npm.ts
@@ -1,5 +1,5 @@
 import { Bug } from '../shared/error'
-import { join as pathJoin, findUp } from '../shared/path'
+import { join as pathJoin, findUp } from '../node/path.public'
 import { pathExists } from '../shared/fs'
 import { content, fileToken } from './logger'
 import { WriteStream } from 'fs-extra'

--- a/packages/core/src/cli/npm.ts
+++ b/packages/core/src/cli/npm.ts
@@ -1,5 +1,5 @@
 import { Bug } from '../shared/error'
-import { joinPath, findPathUp } from '../node/path.public'
+import { joinPath, findPathUp } from '../node/path'
 import { pathExists } from '../shared/fs'
 import { content, fileToken } from './logger'
 import { WriteStream } from 'fs-extra'

--- a/packages/core/src/cli/npm.ts
+++ b/packages/core/src/cli/npm.ts
@@ -1,5 +1,5 @@
 import { Bug } from '../shared/error'
-import { join as pathJoin, findUp } from '../node/path.public'
+import { joinPath, findPathUp } from '../node/path.public'
 import { pathExists } from '../shared/fs'
 import { content, fileToken } from './logger'
 import { WriteStream } from 'fs-extra'
@@ -82,7 +82,7 @@ type AddDependencyOptions = {
  * @param options {AddDependencyOptions} Options to add a dependency.
  */
 export async function addDependencies(options: AddDependencyOptions) {
-  const packageJsonPath = pathJoin(options.directory, 'package.json')
+  const packageJsonPath = joinPath(options.directory, 'package.json')
   const packageJsonExists = await pathExists(packageJsonPath)
   if (!packageJsonExists) {
     throw PackageJsonNotFoundError(options.directory)
@@ -150,14 +150,14 @@ export async function addDependencies(options: AddDependencyOptions) {
 export async function inferDependencyManager(
   fromDirectory: string
 ): Promise<DependencyManager> {
-  const yarnLockPath = await findUp('yarn.lock', {
+  const yarnLockPath = await findPathUp('yarn.lock', {
     cwd: fromDirectory,
     type: 'file',
   })
   if (yarnLockPath) {
     return 'yarn'
   }
-  const pnpmLockPath = await findUp('pnpm-lock.yaml', {
+  const pnpmLockPath = await findPathUp('pnpm-lock.yaml', {
     cwd: fromDirectory,
     type: 'file',
   })

--- a/packages/core/src/cli/project/load/config.ts
+++ b/packages/core/src/cli/project/load/config.ts
@@ -1,5 +1,5 @@
 import { configurationFileName } from '../../constants'
-import { findUp as findPathUp } from '../../../shared/path'
+import { findUp as findPathUp } from '../../../node/path.public'
 import { Configuration } from '../models/configuration'
 import { ModuleLoader } from './module-loader'
 

--- a/packages/core/src/cli/project/load/config.ts
+++ b/packages/core/src/cli/project/load/config.ts
@@ -1,5 +1,5 @@
 import { configurationFileName } from '../../constants'
-import { findPathUp as findPathUp } from '../../../node/path.public'
+import { findPathUp as findPathUp } from '../../../node/path'
 import { Configuration } from '../models/configuration'
 import { ModuleLoader } from './module-loader'
 

--- a/packages/core/src/cli/project/load/config.ts
+++ b/packages/core/src/cli/project/load/config.ts
@@ -1,5 +1,5 @@
 import { configurationFileName } from '../../constants'
-import { findUp as findPathUp } from '../../../node/path.public'
+import { findPathUp as findPathUp } from '../../../node/path.public'
 import { Configuration } from '../models/configuration'
 import { ModuleLoader } from './module-loader'
 

--- a/packages/core/src/cli/project/load/module-loader.test.ts
+++ b/packages/core/src/cli/project/load/module-loader.test.ts
@@ -1,7 +1,7 @@
 import { getModuleLoader } from './module-loader'
-import { describe, test, expect, vi } from 'vitest'
+import { describe, test, expect } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
-import { join as pathJoin } from '../../../node/path.public'
+import { joinPath } from '../../../node/path.public'
 import { writeFile } from '../../../shared/fs'
 
 describe('getModuleLoader', () => {
@@ -12,7 +12,7 @@ describe('getModuleLoader', () => {
         const object = { name: "Test" };
         export default object;
         `
-      const modulePath = pathJoin(tmpDir, 'module.js')
+      const modulePath = joinPath(tmpDir, 'module.js')
       await writeFile(modulePath, moduleContent)
       const moduleLoader = await getModuleLoader(tmpDir)
 
@@ -37,7 +37,7 @@ describe('getModuleLoader', () => {
         const object = { name: "Second" };
         export default object;
         `
-      const modulePath = pathJoin(tmpDir, 'module.js')
+      const modulePath = joinPath(tmpDir, 'module.js')
       await writeFile(modulePath, firstModuleContent)
       const moduleLoader = await getModuleLoader(tmpDir)
 

--- a/packages/core/src/cli/project/load/module-loader.test.ts
+++ b/packages/core/src/cli/project/load/module-loader.test.ts
@@ -1,7 +1,7 @@
 import { getModuleLoader } from './module-loader'
 import { describe, test, expect } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
-import { joinPath } from '../../../node/path.public'
+import { joinPath } from '../../../node/path'
 import { writeFile } from '../../../shared/fs'
 
 describe('getModuleLoader', () => {

--- a/packages/core/src/cli/project/load/module-loader.test.ts
+++ b/packages/core/src/cli/project/load/module-loader.test.ts
@@ -1,7 +1,7 @@
 import { getModuleLoader } from './module-loader'
 import { describe, test, expect, vi } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
-import { join as pathJoin } from '../../../shared/path'
+import { join as pathJoin } from '../../../node/path.public'
 import { writeFile } from '../../../shared/fs'
 
 describe('getModuleLoader', () => {

--- a/packages/core/src/cli/project/load/project.test.ts
+++ b/packages/core/src/cli/project/load/project.test.ts
@@ -4,7 +4,7 @@ import { getModuleLoader } from './module-loader'
 import { describe, test, expect, vi } from 'vitest'
 import { loadProject, ConfigFileNotFoundError } from './project'
 import { models } from '@gestaltjs/testing'
-import { join as pathJoin } from '../../../node/path.public'
+import { joinPath } from '../../../node/path.public'
 import { validateProject } from '../validate/project'
 
 vi.mock('./config')
@@ -47,6 +47,6 @@ describe('loadProject', () => {
     expect(got.directory).toEqual(fromDirectory)
     expect(got.targets).toEqual(project.targets)
     expect(validateProject).toHaveBeenCalledWith(got)
-    expect(got.sourcesGlob).toEqual(pathJoin(fromDirectory, 'src/**/*.{ts,js}'))
+    expect(got.sourcesGlob).toEqual(joinPath(fromDirectory, 'src/**/*.{ts,js}'))
   })
 })

--- a/packages/core/src/cli/project/load/project.test.ts
+++ b/packages/core/src/cli/project/load/project.test.ts
@@ -4,7 +4,7 @@ import { getModuleLoader } from './module-loader'
 import { describe, test, expect, vi } from 'vitest'
 import { loadProject, ConfigFileNotFoundError } from './project'
 import { models } from '@gestaltjs/testing'
-import { join as pathJoin } from '../../../shared/path'
+import { join as pathJoin } from '../../../node/path.public'
 import { validateProject } from '../validate/project'
 
 vi.mock('./config')

--- a/packages/core/src/cli/project/load/project.test.ts
+++ b/packages/core/src/cli/project/load/project.test.ts
@@ -4,7 +4,7 @@ import { getModuleLoader } from './module-loader'
 import { describe, test, expect, vi } from 'vitest'
 import { loadProject, ConfigFileNotFoundError } from './project'
 import { models } from '@gestaltjs/testing'
-import { joinPath } from '../../../node/path.public'
+import { joinPath } from '../../../node/path'
 import { validateProject } from '../validate/project'
 
 vi.mock('./config')

--- a/packages/core/src/cli/project/load/project.ts
+++ b/packages/core/src/cli/project/load/project.ts
@@ -1,6 +1,6 @@
 import { Project } from '../models/project'
 import { Abort } from '../../../shared/error'
-import { dirname, join as pathJoin } from '../../../node/path.public'
+import { dirname, joinPath } from '../../../node/path.public'
 import { loadTargets } from './target'
 import { lookupConfigurationPathTraversing, loadConfig } from './config'
 import { getModuleLoader } from './module-loader'
@@ -42,7 +42,7 @@ export async function loadProject(fromDirectory: string): Promise<Project> {
     const project = {
       configuration,
       directory,
-      sourcesGlob: pathJoin(directory, `src/**/*.{ts,js}`),
+      sourcesGlob: joinPath(directory, `src/**/*.{ts,js}`),
       targets,
     }
     await validateProject(project)

--- a/packages/core/src/cli/project/load/project.ts
+++ b/packages/core/src/cli/project/load/project.ts
@@ -1,6 +1,6 @@
 import { Project } from '../models/project'
 import { Abort } from '../../../shared/error'
-import { dirname, join as pathJoin } from '../../../shared/path'
+import { dirname, join as pathJoin } from '../../../node/path.public'
 import { loadTargets } from './target'
 import { lookupConfigurationPathTraversing, loadConfig } from './config'
 import { getModuleLoader } from './module-loader'

--- a/packages/core/src/cli/project/load/project.ts
+++ b/packages/core/src/cli/project/load/project.ts
@@ -1,6 +1,6 @@
 import { Project } from '../models/project'
 import { Abort } from '../../../shared/error'
-import { dirname, joinPath } from '../../../node/path.public'
+import { parentDirectory, joinPath } from '../../../node/path'
 import { loadTargets } from './target'
 import { lookupConfigurationPathTraversing, loadConfig } from './config'
 import { getModuleLoader } from './module-loader'
@@ -34,7 +34,7 @@ export async function loadProject(fromDirectory: string): Promise<Project> {
   if (!configurationPath) {
     throw ConfigFileNotFoundError()
   }
-  const directory = dirname(configurationPath)
+  const directory = parentDirectory(configurationPath)
   const moduleLoader = await getModuleLoader(directory)
   try {
     const configuration = await loadConfig(configurationPath, moduleLoader)

--- a/packages/core/src/cli/project/load/target.ts
+++ b/packages/core/src/cli/project/load/target.ts
@@ -1,4 +1,4 @@
-import { glob, join as pathJoin } from '../../../node/path.public'
+import { glob, joinPath } from '../../../node/path.public'
 import { mainTargetFileName } from '../../constants'
 import { Targets } from '../models/targets'
 import { loadMainTarget } from './targets/main'
@@ -10,7 +10,7 @@ export async function loadTargets(
 ): Promise<Targets> {
   const globPatterns = (directory: string) =>
     ['ts', 'js'].map((extension) =>
-      pathJoin(
+      joinPath(
         projectDirectory,
         `targets/${directory}/*/${mainTargetFileName}.${extension}`
       )

--- a/packages/core/src/cli/project/load/target.ts
+++ b/packages/core/src/cli/project/load/target.ts
@@ -1,4 +1,4 @@
-import { glob, join as pathJoin } from '../../../shared/path'
+import { glob, join as pathJoin } from '../../../node/path.public'
 import { mainTargetFileName } from '../../constants'
 import { Targets } from '../models/targets'
 import { loadMainTarget } from './targets/main'

--- a/packages/core/src/cli/project/load/target.ts
+++ b/packages/core/src/cli/project/load/target.ts
@@ -1,4 +1,4 @@
-import { glob, joinPath } from '../../../node/path.public'
+import { glob, joinPath } from '../../../node/path'
 import { mainTargetFileName } from '../../constants'
 import { Targets } from '../models/targets'
 import { loadMainTarget } from './targets/main'

--- a/packages/core/src/cli/project/load/targets/main.test.ts
+++ b/packages/core/src/cli/project/load/targets/main.test.ts
@@ -2,11 +2,7 @@ import { loadMainTarget } from './main'
 import { describe, test, expect, vi } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
 import { models } from '@gestaltjs/testing'
-import {
-  dirname,
-  basename,
-  join as pathJoin,
-} from '../../../../node/path.public'
+import { dirname, basename, joinPath } from '../../../../node/path.public'
 import { loadRoutes } from './main/routes'
 import { createRouter } from 'radix3'
 import { Route } from '../../models/targets/main/route'
@@ -17,7 +13,7 @@ describe('loadMainTarget', () => {
   test('loads the target successfully', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const manifestPath = pathJoin(tmpDir, 'gestalt.main.js')
+      const manifestPath = joinPath(tmpDir, 'gestalt.main.js')
       const load = vi.fn()
       const mainTarget = models.testMainTarget()
       const moduleLoader: any = { load }

--- a/packages/core/src/cli/project/load/targets/main.test.ts
+++ b/packages/core/src/cli/project/load/targets/main.test.ts
@@ -2,7 +2,7 @@ import { loadMainTarget } from './main'
 import { describe, test, expect, vi } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
 import { models } from '@gestaltjs/testing'
-import { parentDirectory, basename, joinPath } from '../../../../node/path'
+import { parentDirectory, pathBaseName, joinPath } from '../../../../node/path'
 import { loadRoutes } from './main/routes'
 import { createRouter } from 'radix3'
 import { Route } from '../../models/targets/main/route'
@@ -26,7 +26,7 @@ describe('loadMainTarget', () => {
 
       // Then
       expect(got.manifestPath).toEqual(manifestPath)
-      expect(got.name).toEqual(basename(parentDirectory(manifestPath)))
+      expect(got.name).toEqual(pathBaseName(parentDirectory(manifestPath)))
       expect(got.directory).toEqual(parentDirectory(manifestPath))
       expect(got.router).toBe(router)
     })

--- a/packages/core/src/cli/project/load/targets/main.test.ts
+++ b/packages/core/src/cli/project/load/targets/main.test.ts
@@ -2,7 +2,7 @@ import { loadMainTarget } from './main'
 import { describe, test, expect, vi } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
 import { models } from '@gestaltjs/testing'
-import { dirname, basename, joinPath } from '../../../../node/path.public'
+import { parentDirectory, basename, joinPath } from '../../../../node/path'
 import { loadRoutes } from './main/routes'
 import { createRouter } from 'radix3'
 import { Route } from '../../models/targets/main/route'
@@ -26,8 +26,8 @@ describe('loadMainTarget', () => {
 
       // Then
       expect(got.manifestPath).toEqual(manifestPath)
-      expect(got.name).toEqual(basename(dirname(manifestPath)))
-      expect(got.directory).toEqual(dirname(manifestPath))
+      expect(got.name).toEqual(basename(parentDirectory(manifestPath)))
+      expect(got.directory).toEqual(parentDirectory(manifestPath))
       expect(got.router).toBe(router)
     })
   })

--- a/packages/core/src/cli/project/load/targets/main.test.ts
+++ b/packages/core/src/cli/project/load/targets/main.test.ts
@@ -2,7 +2,11 @@ import { loadMainTarget } from './main'
 import { describe, test, expect, vi } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
 import { models } from '@gestaltjs/testing'
-import { dirname, basename, join as pathJoin } from '../../../../shared/path'
+import {
+  dirname,
+  basename,
+  join as pathJoin,
+} from '../../../../node/path.public'
 import { loadRoutes } from './main/routes'
 import { createRouter } from 'radix3'
 import { Route } from '../../models/targets/main/route'

--- a/packages/core/src/cli/project/load/targets/main.test.ts
+++ b/packages/core/src/cli/project/load/targets/main.test.ts
@@ -2,7 +2,7 @@ import { loadMainTarget } from './main'
 import { describe, test, expect, vi } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
 import { models } from '@gestaltjs/testing'
-import { parentDirectory, pathBaseName, joinPath } from '../../../../node/path'
+import { parentDirectory, pathBasename, joinPath } from '../../../../node/path'
 import { loadRoutes } from './main/routes'
 import { createRouter } from 'radix3'
 import { Route } from '../../models/targets/main/route'
@@ -26,7 +26,7 @@ describe('loadMainTarget', () => {
 
       // Then
       expect(got.manifestPath).toEqual(manifestPath)
-      expect(got.name).toEqual(pathBaseName(parentDirectory(manifestPath)))
+      expect(got.name).toEqual(pathBasename(parentDirectory(manifestPath)))
       expect(got.directory).toEqual(parentDirectory(manifestPath))
       expect(got.router).toBe(router)
     })

--- a/packages/core/src/cli/project/load/targets/main.ts
+++ b/packages/core/src/cli/project/load/targets/main.ts
@@ -1,5 +1,5 @@
 import type { MainTarget } from '../../models/targets/main'
-import { dirname, basename, joinPath } from '../../../../node/path.public'
+import { parentDirectory, basename, joinPath } from '../../../../node/path'
 import { ModuleLoader } from '../module-loader'
 import { loadRoutes } from './main/routes'
 import { loadLayouts } from './main/layouts'
@@ -15,14 +15,14 @@ export async function loadMainTarget(
   manifestPath: string,
   moduleLoader: ModuleLoader
 ): Promise<MainTarget> {
-  const directory = dirname(manifestPath)
+  const directory = parentDirectory(manifestPath)
   const userMainTarget = ((await moduleLoader.load(manifestPath)) as any)
     .default as UserMainTarget
   const routesDirectory = joinPath(directory, 'routes')
   return {
     ...userMainTarget,
     manifestPath,
-    name: basename(dirname(manifestPath)),
+    name: basename(parentDirectory(manifestPath)),
     directory,
     router: await loadRoutes(routesDirectory),
     layouts: await loadLayouts(routesDirectory),

--- a/packages/core/src/cli/project/load/targets/main.ts
+++ b/packages/core/src/cli/project/load/targets/main.ts
@@ -1,5 +1,5 @@
 import type { MainTarget } from '../../models/targets/main'
-import { parentDirectory, pathBaseName, joinPath } from '../../../../node/path'
+import { parentDirectory, pathBasename, joinPath } from '../../../../node/path'
 import { ModuleLoader } from '../module-loader'
 import { loadRoutes } from './main/routes'
 import { loadLayouts } from './main/layouts'
@@ -22,7 +22,7 @@ export async function loadMainTarget(
   return {
     ...userMainTarget,
     manifestPath,
-    name: pathBaseName(parentDirectory(manifestPath)),
+    name: pathBasename(parentDirectory(manifestPath)),
     directory,
     router: await loadRoutes(routesDirectory),
     layouts: await loadLayouts(routesDirectory),

--- a/packages/core/src/cli/project/load/targets/main.ts
+++ b/packages/core/src/cli/project/load/targets/main.ts
@@ -1,5 +1,9 @@
 import type { MainTarget } from '../../models/targets/main'
-import { dirname, basename, join as pathJoin } from '../../../../shared/path'
+import {
+  dirname,
+  basename,
+  join as pathJoin,
+} from '../../../../node/path.public'
 import { ModuleLoader } from '../module-loader'
 import { loadRoutes } from './main/routes'
 import { loadLayouts } from './main/layouts'

--- a/packages/core/src/cli/project/load/targets/main.ts
+++ b/packages/core/src/cli/project/load/targets/main.ts
@@ -1,9 +1,5 @@
 import type { MainTarget } from '../../models/targets/main'
-import {
-  dirname,
-  basename,
-  join as pathJoin,
-} from '../../../../node/path.public'
+import { dirname, basename, joinPath } from '../../../../node/path.public'
 import { ModuleLoader } from '../module-loader'
 import { loadRoutes } from './main/routes'
 import { loadLayouts } from './main/layouts'
@@ -22,7 +18,7 @@ export async function loadMainTarget(
   const directory = dirname(manifestPath)
   const userMainTarget = ((await moduleLoader.load(manifestPath)) as any)
     .default as UserMainTarget
-  const routesDirectory = pathJoin(directory, 'routes')
+  const routesDirectory = joinPath(directory, 'routes')
   return {
     ...userMainTarget,
     manifestPath,

--- a/packages/core/src/cli/project/load/targets/main.ts
+++ b/packages/core/src/cli/project/load/targets/main.ts
@@ -1,5 +1,5 @@
 import type { MainTarget } from '../../models/targets/main'
-import { parentDirectory, basename, joinPath } from '../../../../node/path'
+import { parentDirectory, pathBaseName, joinPath } from '../../../../node/path'
 import { ModuleLoader } from '../module-loader'
 import { loadRoutes } from './main/routes'
 import { loadLayouts } from './main/layouts'
@@ -22,7 +22,7 @@ export async function loadMainTarget(
   return {
     ...userMainTarget,
     manifestPath,
-    name: basename(parentDirectory(manifestPath)),
+    name: pathBaseName(parentDirectory(manifestPath)),
     directory,
     router: await loadRoutes(routesDirectory),
     layouts: await loadLayouts(routesDirectory),

--- a/packages/core/src/cli/project/load/targets/main/layout.test.ts
+++ b/packages/core/src/cli/project/load/targets/main/layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
-import { join as pathJoin, dirname } from '../../../../../shared/path'
+import { join as pathJoin, dirname } from '../../../../../node/path.public'
 import { loadLayouts } from './layouts'
 import { writeFile, makeDirectory } from '../../../../../shared/fs'
 

--- a/packages/core/src/cli/project/load/targets/main/layout.test.ts
+++ b/packages/core/src/cli/project/load/targets/main/layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
-import { joinPath, dirname } from '../../../../../node/path.public'
+import { joinPath, parentDirectory } from '../../../../../node/path'
 import { loadLayouts } from './layouts'
 import { writeFile, makeDirectory } from '../../../../../shared/fs'
 
@@ -10,8 +10,8 @@ describe('loadLayouts', () => {
       // Given
       const settingsLayoutPath = joinPath(tmpDir, 'settings/_layout.jsx')
       const homeLayout = joinPath(tmpDir, '_layout.jsx')
-      await makeDirectory(dirname(settingsLayoutPath))
-      await makeDirectory(dirname(homeLayout))
+      await makeDirectory(parentDirectory(settingsLayoutPath))
+      await makeDirectory(parentDirectory(homeLayout))
       await writeFile(settingsLayoutPath, '')
       await writeFile(homeLayout, '')
 

--- a/packages/core/src/cli/project/load/targets/main/layout.test.ts
+++ b/packages/core/src/cli/project/load/targets/main/layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
-import { join as pathJoin, dirname } from '../../../../../node/path.public'
+import { joinPath, dirname } from '../../../../../node/path.public'
 import { loadLayouts } from './layouts'
 import { writeFile, makeDirectory } from '../../../../../shared/fs'
 
@@ -8,8 +8,8 @@ describe('loadLayouts', () => {
   test('loads layouts named _layout.* in any subdirectory', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const settingsLayoutPath = pathJoin(tmpDir, 'settings/_layout.jsx')
-      const homeLayout = pathJoin(tmpDir, '_layout.jsx')
+      const settingsLayoutPath = joinPath(tmpDir, 'settings/_layout.jsx')
+      const homeLayout = joinPath(tmpDir, '_layout.jsx')
       await makeDirectory(dirname(settingsLayoutPath))
       await makeDirectory(dirname(homeLayout))
       await writeFile(settingsLayoutPath, '')

--- a/packages/core/src/cli/project/load/targets/main/layouts.ts
+++ b/packages/core/src/cli/project/load/targets/main/layouts.ts
@@ -1,5 +1,5 @@
 import {
-  join as pathJoin,
+  joinPath,
   glob,
   relative as relativePath,
 } from '../../../../../node/path.public'
@@ -15,7 +15,7 @@ import {
 export async function loadLayouts(
   routesDirectory: string
 ): Promise<{ [key: string]: string }> {
-  const layouts = await glob(pathJoin(routesDirectory, '**/_layout.*'))
+  const layouts = await glob(joinPath(routesDirectory, '**/_layout.*'))
   const layoutEntries = layouts.map((layoutFile) => {
     const urlPath = `/${relativePath(
       routesDirectory,

--- a/packages/core/src/cli/project/load/targets/main/layouts.ts
+++ b/packages/core/src/cli/project/load/targets/main/layouts.ts
@@ -1,8 +1,4 @@
-import {
-  joinPath,
-  glob,
-  relative as relativePath,
-} from '../../../../../node/path'
+import { joinPath, glob, relativePath } from '../../../../../node/path'
 
 /**
  * This functions finds all the layout files under a target's routes directory,

--- a/packages/core/src/cli/project/load/targets/main/layouts.ts
+++ b/packages/core/src/cli/project/load/targets/main/layouts.ts
@@ -2,7 +2,7 @@ import {
   join as pathJoin,
   glob,
   relative as relativePath,
-} from '../../../../../shared/path'
+} from '../../../../../node/path.public'
 
 /**
  * This functions finds all the layout files under a target's routes directory,

--- a/packages/core/src/cli/project/load/targets/main/layouts.ts
+++ b/packages/core/src/cli/project/load/targets/main/layouts.ts
@@ -2,7 +2,7 @@ import {
   joinPath,
   glob,
   relative as relativePath,
-} from '../../../../../node/path.public'
+} from '../../../../../node/path'
 
 /**
  * This functions finds all the layout files under a target's routes directory,

--- a/packages/core/src/cli/project/load/targets/main/routes.test.ts
+++ b/packages/core/src/cli/project/load/targets/main/routes.test.ts
@@ -2,7 +2,7 @@ import { loadRoutes } from './routes'
 import { describe, test, expect, vi } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
 import { models } from '@gestaltjs/testing'
-import { dirname, joinPath } from '../../../../../node/path.public'
+import { parentDirectory, joinPath } from '../../../../../node/path'
 import { writeFile, makeDirectory } from '../../../../../shared/fs'
 import { Route } from '../../../models/targets/main/route'
 
@@ -20,9 +20,9 @@ describe('loadRoutes', () => {
       const postListFilePath = joinPath(tmpDir, 'posts/[post].list.ts')
       const postGetFilePath = joinPath(tmpDir, 'posts/[post].get.js')
 
-      await makeDirectory(dirname(aboutUIFilePath))
-      await makeDirectory(dirname(settingsUIFilePath))
-      await makeDirectory(dirname(postUIFilePath))
+      await makeDirectory(parentDirectory(aboutUIFilePath))
+      await makeDirectory(parentDirectory(settingsUIFilePath))
+      await makeDirectory(parentDirectory(postUIFilePath))
 
       await writeFile(aboutUIFilePath, '')
       await writeFile(settingsUIFilePath, '')

--- a/packages/core/src/cli/project/load/targets/main/routes.test.ts
+++ b/packages/core/src/cli/project/load/targets/main/routes.test.ts
@@ -2,7 +2,7 @@ import { loadRoutes } from './routes'
 import { describe, test, expect, vi } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
 import { models } from '@gestaltjs/testing'
-import { dirname, join as pathJoin } from '../../../../../node/path.public'
+import { dirname, joinPath } from '../../../../../node/path.public'
 import { writeFile, makeDirectory } from '../../../../../shared/fs'
 import { Route } from '../../../models/targets/main/route'
 
@@ -13,12 +13,12 @@ describe('loadRoutes', () => {
       const load = vi.fn()
       const mainTarget = models.testMainTarget()
       load.mockResolvedValue(mainTarget)
-      const aboutUIFilePath = pathJoin(tmpDir, 'about.ui.static.jsx')
-      const settingsUIFilePath = pathJoin(tmpDir, 'settings/index.ui.jsx')
-      const postsLayoutFile = pathJoin(tmpDir, 'posts/_layout.jsx')
-      const postUIFilePath = pathJoin(tmpDir, 'posts/[post].ui.static.jsx')
-      const postListFilePath = pathJoin(tmpDir, 'posts/[post].list.ts')
-      const postGetFilePath = pathJoin(tmpDir, 'posts/[post].get.js')
+      const aboutUIFilePath = joinPath(tmpDir, 'about.ui.static.jsx')
+      const settingsUIFilePath = joinPath(tmpDir, 'settings/index.ui.jsx')
+      const postsLayoutFile = joinPath(tmpDir, 'posts/_layout.jsx')
+      const postUIFilePath = joinPath(tmpDir, 'posts/[post].ui.static.jsx')
+      const postListFilePath = joinPath(tmpDir, 'posts/[post].list.ts')
+      const postGetFilePath = joinPath(tmpDir, 'posts/[post].get.js')
 
       await makeDirectory(dirname(aboutUIFilePath))
       await makeDirectory(dirname(settingsUIFilePath))

--- a/packages/core/src/cli/project/load/targets/main/routes.test.ts
+++ b/packages/core/src/cli/project/load/targets/main/routes.test.ts
@@ -2,7 +2,7 @@ import { loadRoutes } from './routes'
 import { describe, test, expect, vi } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
 import { models } from '@gestaltjs/testing'
-import { dirname, join as pathJoin } from '../../../../../shared/path'
+import { dirname, join as pathJoin } from '../../../../../node/path.public'
 import { writeFile, makeDirectory } from '../../../../../shared/fs'
 import { Route } from '../../../models/targets/main/route'
 

--- a/packages/core/src/cli/project/load/targets/main/routes.ts
+++ b/packages/core/src/cli/project/load/targets/main/routes.ts
@@ -5,7 +5,7 @@ import {
   joinPath,
   glob,
   parentDirectory,
-  pathBaseName,
+  pathBasename,
   relative as relativePath,
   parse as parsePath,
 } from '../../../../../node/path'
@@ -133,7 +133,7 @@ async function filePathIfExists(
 function getFilePathWithoutExtension(filePath: string): string {
   return joinPath(
     parentDirectory(filePath),
-    parsePath(pathBaseName(filePath)).name
+    parsePath(pathBasename(filePath)).name
   )
     .replace('.ui.static', '')
     .replace('.ui', '')

--- a/packages/core/src/cli/project/load/targets/main/routes.ts
+++ b/packages/core/src/cli/project/load/targets/main/routes.ts
@@ -2,7 +2,7 @@ import { Route } from '../../../models/targets/main/route'
 import { RadixRouter } from 'radix3'
 import { createRouter } from 'radix3'
 import {
-  join as pathJoin,
+  joinPath,
   glob,
   dirname,
   basename,
@@ -43,10 +43,10 @@ export async function loadRoutes(
  * @returns {Promise<string[]>} A promise that resolves with the paths to the files representing the routes.
  */
 async function getUIRouteFilePaths(directory: string): Promise<string[]> {
-  return await glob(pathJoin(directory, '**/*.ui.*'), {
+  return await glob(joinPath(directory, '**/*.ui.*'), {
     ignore: [
-      pathJoin(directory, '**/*.list.*'),
-      pathJoin(directory, '**/*.get.*'),
+      joinPath(directory, '**/*.list.*'),
+      joinPath(directory, '**/*.get.*'),
     ],
   })
 }
@@ -131,7 +131,7 @@ async function filePathIfExists(
  * @returns {string} The file path without the extensions.
  */
 function getFilePathWithoutExtension(filePath: string): string {
-  return pathJoin(dirname(filePath), parsePath(basename(filePath)).name)
+  return joinPath(dirname(filePath), parsePath(basename(filePath)).name)
     .replace('.ui.static', '')
     .replace('.ui', '')
 }

--- a/packages/core/src/cli/project/load/targets/main/routes.ts
+++ b/packages/core/src/cli/project/load/targets/main/routes.ts
@@ -4,11 +4,11 @@ import { createRouter } from 'radix3'
 import {
   joinPath,
   glob,
-  dirname,
+  parentDirectory,
   basename,
   relative as relativePath,
   parse as parsePath,
-} from '../../../../../node/path.public'
+} from '../../../../../node/path'
 import { pathExists } from '../../../../../shared/fs'
 
 /**
@@ -131,7 +131,7 @@ async function filePathIfExists(
  * @returns {string} The file path without the extensions.
  */
 function getFilePathWithoutExtension(filePath: string): string {
-  return joinPath(dirname(filePath), parsePath(basename(filePath)).name)
+  return joinPath(parentDirectory(filePath), parsePath(basename(filePath)).name)
     .replace('.ui.static', '')
     .replace('.ui', '')
 }

--- a/packages/core/src/cli/project/load/targets/main/routes.ts
+++ b/packages/core/src/cli/project/load/targets/main/routes.ts
@@ -8,7 +8,7 @@ import {
   basename,
   relative as relativePath,
   parse as parsePath,
-} from '../../../../../shared/path'
+} from '../../../../../node/path.public'
 import { pathExists } from '../../../../../shared/fs'
 
 /**

--- a/packages/core/src/cli/project/load/targets/main/routes.ts
+++ b/packages/core/src/cli/project/load/targets/main/routes.ts
@@ -6,8 +6,8 @@ import {
   glob,
   parentDirectory,
   pathBasename,
-  relative as relativePath,
-  parse as parsePath,
+  relativePath,
+  parsePath,
 } from '../../../../../node/path'
 import { pathExists } from '../../../../../shared/fs'
 

--- a/packages/core/src/cli/project/load/targets/main/routes.ts
+++ b/packages/core/src/cli/project/load/targets/main/routes.ts
@@ -5,7 +5,7 @@ import {
   joinPath,
   glob,
   parentDirectory,
-  basename,
+  pathBaseName,
   relative as relativePath,
   parse as parsePath,
 } from '../../../../../node/path'
@@ -131,7 +131,10 @@ async function filePathIfExists(
  * @returns {string} The file path without the extensions.
  */
 function getFilePathWithoutExtension(filePath: string): string {
-  return joinPath(parentDirectory(filePath), parsePath(basename(filePath)).name)
+  return joinPath(
+    parentDirectory(filePath),
+    parsePath(pathBaseName(filePath)).name
+  )
     .replace('.ui.static', '')
     .replace('.ui', '')
 }

--- a/packages/core/src/cli/template.test.ts
+++ b/packages/core/src/cli/template.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
 import { ScaffoldOptions, scaffold } from './template'
-import { joinPath } from '../node/path.public'
+import { joinPath } from '../node/path'
 import { writeFile, pathExists, readFile, makeDirectory } from '../shared/fs'
 
 describe('scaffold basic file', () => {

--- a/packages/core/src/cli/template.test.ts
+++ b/packages/core/src/cli/template.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
 import { ScaffoldOptions, scaffold } from './template'
-import { join as joinPath } from '../node/path.public'
+import { joinPath } from '../node/path.public'
 import { writeFile, pathExists, readFile, makeDirectory } from '../shared/fs'
 
 describe('scaffold basic file', () => {

--- a/packages/core/src/cli/template.test.ts
+++ b/packages/core/src/cli/template.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
 import { ScaffoldOptions, scaffold } from './template'
-import { join as joinPath } from '../shared/path'
+import { join as joinPath } from '../node/path.public'
 import { writeFile, pathExists, readFile, makeDirectory } from '../shared/fs'
 
 describe('scaffold basic file', () => {

--- a/packages/core/src/cli/template.ts
+++ b/packages/core/src/cli/template.ts
@@ -1,5 +1,5 @@
 import fg from 'fast-glob'
-import { join as joinPath, relative, dirname } from '../shared/path'
+import { join as joinPath, relative, dirname } from '../node/path.public'
 import { copyFile, makeDirectory, writeFile, readFile } from '../shared/fs'
 import Handlebars from 'handlebars'
 

--- a/packages/core/src/cli/template.ts
+++ b/packages/core/src/cli/template.ts
@@ -1,5 +1,5 @@
 import fg from 'fast-glob'
-import { joinPath, relative, parentDirectory } from '../node/path'
+import { joinPath, relativePath, parentDirectory } from '../node/path'
 import { copyFile, makeDirectory, writeFile, readFile } from '../shared/fs'
 import Handlebars from 'handlebars'
 
@@ -24,8 +24,8 @@ export async function scaffold(scaffoldOptions: ScaffoldOptions) {
   )
   await Promise.all(
     entries.map(async (sourceFile) => {
-      const relativePath = relative(scaffoldOptions.sourceDirectory, sourceFile)
-      let targetFile = joinPath(scaffoldOptions.targetDirectory, relativePath)
+      const path = relativePath(scaffoldOptions.sourceDirectory, sourceFile)
+      let targetFile = joinPath(scaffoldOptions.targetDirectory, path)
       if (targetFile.endsWith('.hbs')) {
         const sourceContent = await readFile(sourceFile)
         const contentTemplate = Handlebars.compile(sourceContent)

--- a/packages/core/src/cli/template.ts
+++ b/packages/core/src/cli/template.ts
@@ -1,5 +1,5 @@
 import fg from 'fast-glob'
-import { joinPath, relative, dirname } from '../node/path.public'
+import { joinPath, relative, parentDirectory } from '../node/path'
 import { copyFile, makeDirectory, writeFile, readFile } from '../shared/fs'
 import Handlebars from 'handlebars'
 
@@ -33,11 +33,11 @@ export async function scaffold(scaffoldOptions: ScaffoldOptions) {
         const fileNameTemplate = Handlebars.compile(targetFile)
         targetFile = fileNameTemplate(scaffoldOptions.data)
         targetFile = targetFile.replace('.hbs', '')
-        const targetFileDirectory = dirname(targetFile)
+        const targetFileDirectory = parentDirectory(targetFile)
         await makeDirectory(targetFileDirectory)
         await writeFile(targetFile, targetContent)
       } else {
-        const targetFileDirectory = dirname(targetFile)
+        const targetFileDirectory = parentDirectory(targetFile)
         await makeDirectory(targetFileDirectory)
         await copyFile(sourceFile, targetFile)
       }

--- a/packages/core/src/cli/template.ts
+++ b/packages/core/src/cli/template.ts
@@ -1,5 +1,5 @@
 import fg from 'fast-glob'
-import { join as joinPath, relative, dirname } from '../node/path.public'
+import { joinPath, relative, dirname } from '../node/path.public'
 import { copyFile, makeDirectory, writeFile, readFile } from '../shared/fs'
 import Handlebars from 'handlebars'
 

--- a/packages/core/src/cli/tsc.test.ts
+++ b/packages/core/src/cli/tsc.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from 'vitest'
 import { exec } from './system'
-import { findPathUp, dirname } from '../node/path.public'
+import { findPathUp, parentDirectory } from '../node/path'
 import { run, TSCNotFoundError } from './tsc'
 
 vi.mock('./system')
@@ -12,7 +12,7 @@ describe('run', () => {
     const tscPath = '/test/tsc'
     const dirnamePath = '/gestalt/tsc'
     vi.mocked(findPathUp).mockResolvedValue(tscPath)
-    vi.mocked(dirname).mockReturnValue(dirnamePath)
+    vi.mocked(parentDirectory).mockReturnValue(dirnamePath)
     const args = ['foo']
     const cwd = '/project'
 
@@ -30,7 +30,7 @@ describe('run', () => {
     // Given
     const eslintTSDirectory = '/gestalt/tsc'
     vi.mocked(findPathUp).mockResolvedValue(undefined)
-    vi.mocked(dirname).mockReturnValue(eslintTSDirectory)
+    vi.mocked(parentDirectory).mockReturnValue(eslintTSDirectory)
     const args = ['foo']
     const cwd = '/project'
 

--- a/packages/core/src/cli/tsc.test.ts
+++ b/packages/core/src/cli/tsc.test.ts
@@ -4,7 +4,7 @@ import { findPathUp, parentDirectory } from '../node/path'
 import { run, TSCNotFoundError } from './tsc'
 
 vi.mock('./system')
-vi.mock('../node/path.public')
+vi.mock('../node/path')
 
 describe('run', () => {
   test('runs tsc', async () => {

--- a/packages/core/src/cli/tsc.test.ts
+++ b/packages/core/src/cli/tsc.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from 'vitest'
 import { exec } from './system'
-import { findUp, dirname } from '../shared/path'
+import { findUp, dirname } from '../node/path.public'
 import { run, TSCNotFoundError } from './tsc'
 
 vi.mock('./system')

--- a/packages/core/src/cli/tsc.test.ts
+++ b/packages/core/src/cli/tsc.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi } from 'vitest'
 import { exec } from './system'
-import { findUp, dirname } from '../node/path.public'
+import { findPathUp, dirname } from '../node/path.public'
 import { run, TSCNotFoundError } from './tsc'
 
 vi.mock('./system')
@@ -11,7 +11,7 @@ describe('run', () => {
     // Given
     const tscPath = '/test/tsc'
     const dirnamePath = '/gestalt/tsc'
-    vi.mocked(findUp).mockResolvedValue(tscPath)
+    vi.mocked(findPathUp).mockResolvedValue(tscPath)
     vi.mocked(dirname).mockReturnValue(dirnamePath)
     const args = ['foo']
     const cwd = '/project'
@@ -20,7 +20,7 @@ describe('run', () => {
     await run(args, cwd)
 
     // Then
-    expect(findUp).toHaveBeenCalledWith('node_modules/.bin/tsc', {
+    expect(findPathUp).toHaveBeenCalledWith('node_modules/.bin/tsc', {
       cwd: dirnamePath,
     })
     expect(exec).toHaveBeenCalledWith(tscPath, args, { stdio: 'inherit', cwd })
@@ -29,7 +29,7 @@ describe('run', () => {
   test('aborts when typescript compiler cannot be found', async () => {
     // Given
     const eslintTSDirectory = '/gestalt/tsc'
-    vi.mocked(findUp).mockResolvedValue(undefined)
+    vi.mocked(findPathUp).mockResolvedValue(undefined)
     vi.mocked(dirname).mockReturnValue(eslintTSDirectory)
     const args = ['foo']
     const cwd = '/project'

--- a/packages/core/src/cli/tsc.test.ts
+++ b/packages/core/src/cli/tsc.test.ts
@@ -4,7 +4,7 @@ import { findUp, dirname } from '../node/path.public'
 import { run, TSCNotFoundError } from './tsc'
 
 vi.mock('./system')
-vi.mock('../shared/path')
+vi.mock('../node/path.public')
 
 describe('run', () => {
   test('runs tsc', async () => {

--- a/packages/core/src/cli/tsc.ts
+++ b/packages/core/src/cli/tsc.ts
@@ -1,6 +1,6 @@
 import { Abort } from '../shared/error'
 import { exec } from './system'
-import { findUp, dirname } from '../shared/path'
+import { findUp, dirname } from '../node/path.public'
 import { fileURLToPath } from 'url'
 
 export const TSCNotFoundError = () => {

--- a/packages/core/src/cli/tsc.ts
+++ b/packages/core/src/cli/tsc.ts
@@ -1,6 +1,6 @@
 import { Abort } from '../shared/error'
 import { exec } from './system'
-import { findUp, dirname } from '../node/path.public'
+import { findPathUp, dirname } from '../node/path.public'
 import { fileURLToPath } from 'url'
 
 export const TSCNotFoundError = () => {
@@ -9,7 +9,7 @@ export const TSCNotFoundError = () => {
 
 export async function run(args: string[], cwd: string) {
   const __dirname = dirname(fileURLToPath(import.meta.url))
-  const tscPath = await findUp('node_modules/.bin/tsc', { cwd: __dirname })
+  const tscPath = await findPathUp('node_modules/.bin/tsc', { cwd: __dirname })
   if (!tscPath) {
     throw TSCNotFoundError()
   }

--- a/packages/core/src/cli/tsc.ts
+++ b/packages/core/src/cli/tsc.ts
@@ -1,6 +1,6 @@
 import { Abort } from '../shared/error'
 import { exec } from './system'
-import { findPathUp, dirname } from '../node/path.public'
+import { findPathUp, parentDirectory } from '../node/path'
 import { fileURLToPath } from 'url'
 
 export const TSCNotFoundError = () => {
@@ -8,7 +8,7 @@ export const TSCNotFoundError = () => {
 }
 
 export async function run(args: string[], cwd: string) {
-  const __dirname = dirname(fileURLToPath(import.meta.url))
+  const __dirname = parentDirectory(fileURLToPath(import.meta.url))
   const tscPath = await findPathUp('node_modules/.bin/tsc', { cwd: __dirname })
   if (!tscPath) {
     throw TSCNotFoundError()

--- a/packages/core/src/node/path.public.ts
+++ b/packages/core/src/node/path.public.ts
@@ -29,7 +29,7 @@ export function moduleDirname(url: string): string {
  * @param path {string} Path to relativize
  * @returns {string} Relativized path.
  */
-export function relativize(path: string): string {
+export function relativizePath(path: string): string {
   const result = commondir([path, process.cwd()])
   if (result !== '/') {
     return relativePath(process.cwd(), path)

--- a/packages/core/src/node/path.public.ts
+++ b/packages/core/src/node/path.public.ts
@@ -1,14 +1,32 @@
-export { findUp } from 'find-up'
+export { findUp as findPathUp } from 'find-up'
 export { default as glob } from 'fast-glob'
-export * from 'pathe'
 import process from 'node:process'
-export { pathEqual } from 'path-equal'
-import { relative as relativePath, dirname } from 'pathe'
+import { relative as relativePath, dirname as patheDirname } from 'pathe'
 import { fileURLToPath } from 'url'
+export { basename, resolve, relative, parse } from 'pathe'
+import { join } from 'pathe'
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import commondir from 'commondir'
+
+/**
+ * Given a path, it returns the path of the parent directory.
+ * @param path {string} Path to the directory of the given path.
+ * @returns {string} The path to the parent directory.
+ */
+export function dirname(path: string): string {
+  return patheDirname(path)
+}
+
+/**
+ * Joins path components to form a path.
+ * @param paths {string[]} The path components to concatenate.
+ * @returns Joined path.
+ */
+export function joinPath(...paths: string[]): string {
+  return join(...paths)
+}
 
 /**
  * This utility function replaces the CJS __dirname variable exposed
@@ -18,7 +36,7 @@ import commondir from 'commondir'
  * @returns
  */
 export function moduleDirname(url: string): string {
-  return dirname(fileURLToPath(url))
+  return patheDirname(fileURLToPath(url))
 }
 
 /**
@@ -44,6 +62,6 @@ export function relativizePath(path: string): string {
  * @param url {URL} URL to obtain the path from.
  * @returns {string} The string representing the path.
  */
-export function fromURL(url: string | URL): string {
+export function pathFromURL(url: string | URL): string {
   return fileURLToPath(url)
 }

--- a/packages/core/src/node/path.ts
+++ b/packages/core/src/node/path.ts
@@ -16,11 +16,11 @@ import commondir from 'commondir'
 
 /**
  * Given a path, it returns the last component. For example, if the path
- * is /src/project/index.ts, pathBaseName will yield "index.ts".
+ * is /src/project/index.ts, pathBasename will yield "index.ts".
  * @param path {string} Path those basename will be returned.
  * @returns {string} The path basename.
  */
-export function pathBaseName(path: string): string {
+export function pathBasename(path: string): string {
   return basename(path)
 }
 

--- a/packages/core/src/node/path.ts
+++ b/packages/core/src/node/path.ts
@@ -1,20 +1,53 @@
+// TODO: Move to fs
 export { findUp as findPathUp } from 'find-up'
+// TODO: Move to fs
 export { default as glob } from 'fast-glob'
 import process from 'node:process'
 import {
-  relative as relativePath,
   dirname as patheDirname,
   basename,
   resolve,
   parse,
   join,
+  relative,
 } from 'pathe'
 import { fileURLToPath } from 'url'
-export { relative, parse } from 'pathe'
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import commondir from 'commondir'
+
+/**
+ * Joins all given path components together using the platform-specific separator as a delimiter,
+ * then normalizes the resulting path.
+ * Zero-length path segments are ignored. If the joined path string is a zero-length string then '.' will be returned,
+ * representing the current working directory.
+ * @param paths {string[]} The path components to concatenate.
+ * @returns Joined path.
+ */
+export function joinPath(...components: string[]): string {
+  return join(...components)
+}
+
+/**
+ * This utility function replaces the CJS __dirname variable exposed
+ * by Node. This method is expected to be invoked passing the import.meta.url
+ * variable that represents the caller's module.
+ * @param url {URL} The module URL obtained from import.meta.url
+ * @returns
+ */
+export function moduleDirname(url: string): string {
+  return patheDirname(fileURLToPath(url))
+}
+
+/**
+ * Given a path, it returns the path of the parent directory.
+ * @param path {string} Path to the directory of the given path.
+ * @returns {string} The path to the parent directory.
+ */
+export function parentDirectory(path: string): string {
+  return patheDirname(path)
+}
 
 /**
  * Parses a string that represents a path and returns a path.ParsedPath
@@ -24,17 +57,6 @@ import commondir from 'commondir'
  */
 export function parsePath(path: string): ReturnType<typeof parse> {
   return parse(path)
-}
-
-/**
- * The right-most parameter is considered {to}. Other parameters are considered an array of {from}.
- * Starting from leftmost {from} parameter, resolves {to} to an absolute path.
- * If {to} isn't already absolute, {from} arguments are prepended in right to left order, until an absolute path is found. If after using all {from} paths still no absolute path is found, the current working directory is used as well. The resulting path is normalized, and trailing slashes are removed unless the path gets resolved to the root directory.
- * @param pathComponents {string[]} String paths to join. Non-string arguments are ignored.
- * @returns {string} Resolved path.
- */
-export function resolvePath(...pathComponents: string[]): string {
-  return resolve(...pathComponents)
 }
 
 /**
@@ -48,32 +70,27 @@ export function pathBasename(path: string): string {
 }
 
 /**
- * Given a path, it returns the path of the parent directory.
- * @param path {string} Path to the directory of the given path.
- * @returns {string} The path to the parent directory.
+ * This function ensures the correct decodings of percent-encoded characters as
+ * well as ensuring a cross-platform valid absolute path string.
+ * @param url {URL} URL to obtain the path from.
+ * @returns {string} The string representing the path.
  */
-export function parentDirectory(path: string): string {
-  return patheDirname(path)
+export function pathFromURL(url: string | URL): string {
+  return fileURLToPath(url)
 }
 
 /**
- * Joins path components to form a path.
- * @param paths {string[]} The path components to concatenate.
- * @returns Joined path.
+ * Solve the relative path from {from} to {to}. At times we have two absolute paths,
+ * and we need to derive the relative path from one to the other. For example:
+ *   - From: /path/to/project
+ *   - To: /path/to/project/src/index.ts
+ *   - Output: src/index.ts
+ * @param from {string} Path used as a reference.
+ * @param to {string} Path to relativize.
+ * @returns {string} The relative path.
  */
-export function joinPath(...paths: string[]): string {
-  return join(...paths)
-}
-
-/**
- * This utility function replaces the CJS __dirname variable exposed
- * by Node. This method is expected to be invoked passing the import.meta.url
- * variable that represents the caller's module.
- * @param url {URL} The module URL obtained from import.meta.url
- * @returns
- */
-export function moduleDirname(url: string): string {
-  return patheDirname(fileURLToPath(url))
+export function relativePath(from: string, to: string): string {
+  return relative(from, to)
 }
 
 /**
@@ -94,11 +111,10 @@ export function relativizePath(path: string): string {
 }
 
 /**
- * This function ensures the correct decodings of percent-encoded characters as
- * well as ensuring a cross-platform valid absolute path string.
- * @param url {URL} URL to obtain the path from.
- * @returns {string} The string representing the path.
+ * It resolves a sequence of paths or path segments into an absolute path.
+ * @param pathComponents {string[]} String paths to join. Non-string arguments are ignored.
+ * @returns {string} Resolved path.
  */
-export function pathFromURL(url: string | URL): string {
-  return fileURLToPath(url)
+export function resolvePath(...pathComponents: string[]): string {
+  return resolve(...pathComponents)
 }

--- a/packages/core/src/node/path.ts
+++ b/packages/core/src/node/path.ts
@@ -5,14 +5,37 @@ import {
   relative as relativePath,
   dirname as patheDirname,
   basename,
+  resolve,
+  parse,
+  join,
 } from 'pathe'
 import { fileURLToPath } from 'url'
-export { resolve, relative, parse } from 'pathe'
-import { join } from 'pathe'
+export { relative, parse } from 'pathe'
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import commondir from 'commondir'
+
+/**
+ * Parses a string that represents a path and returns a path.ParsedPath
+ * instance that exposes attributes to access information about the path.
+ * @param path {path.ParsedPath} Parsed path.
+ * @returns
+ */
+export function parsePath(path: string): ReturnType<typeof parse> {
+  return parse(path)
+}
+
+/**
+ * The right-most parameter is considered {to}. Other parameters are considered an array of {from}.
+ * Starting from leftmost {from} parameter, resolves {to} to an absolute path.
+ * If {to} isn't already absolute, {from} arguments are prepended in right to left order, until an absolute path is found. If after using all {from} paths still no absolute path is found, the current working directory is used as well. The resulting path is normalized, and trailing slashes are removed unless the path gets resolved to the root directory.
+ * @param pathComponents {string[]} String paths to join. Non-string arguments are ignored.
+ * @returns {string} Resolved path.
+ */
+export function resolvePath(...pathComponents: string[]): string {
+  return resolve(...pathComponents)
+}
 
 /**
  * Given a path, it returns the last component. For example, if the path

--- a/packages/core/src/node/path.ts
+++ b/packages/core/src/node/path.ts
@@ -15,7 +15,7 @@ import commondir from 'commondir'
  * @param path {string} Path to the directory of the given path.
  * @returns {string} The path to the parent directory.
  */
-export function dirname(path: string): string {
+export function parentDirectory(path: string): string {
   return patheDirname(path)
 }
 

--- a/packages/core/src/node/path.ts
+++ b/packages/core/src/node/path.ts
@@ -1,14 +1,28 @@
 export { findUp as findPathUp } from 'find-up'
 export { default as glob } from 'fast-glob'
 import process from 'node:process'
-import { relative as relativePath, dirname as patheDirname } from 'pathe'
+import {
+  relative as relativePath,
+  dirname as patheDirname,
+  basename,
+} from 'pathe'
 import { fileURLToPath } from 'url'
-export { basename, resolve, relative, parse } from 'pathe'
+export { resolve, relative, parse } from 'pathe'
 import { join } from 'pathe'
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import commondir from 'commondir'
+
+/**
+ * Given a path, it returns the last component. For example, if the path
+ * is /src/project/index.ts, pathBaseName will yield "index.ts".
+ * @param path {string} Path those basename will be returned.
+ * @returns {string} The path basename.
+ */
+export function pathBaseName(path: string): string {
+  return basename(path)
+}
 
 /**
  * Given a path, it returns the path of the parent directory.

--- a/packages/core/src/shared/fs.test.ts
+++ b/packages/core/src/shared/fs.test.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from './fs'
-import { join as pathJoin } from '../shared/path'
+import { join as pathJoin } from '../node/path.public'
 
 import { describe, test, expect } from 'vitest'
 import { temporary } from '@gestaltjs/testing'

--- a/packages/core/src/shared/fs.test.ts
+++ b/packages/core/src/shared/fs.test.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from './fs'
-import { joinPath } from '../node/path.public'
+import { joinPath } from '../node/path'
 
 import { describe, test, expect } from 'vitest'
 import { temporary } from '@gestaltjs/testing'

--- a/packages/core/src/shared/fs.test.ts
+++ b/packages/core/src/shared/fs.test.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from './fs'
-import { join as pathJoin } from '../node/path.public'
+import { joinPath } from '../node/path.public'
 
 import { describe, test, expect } from 'vitest'
 import { temporary } from '@gestaltjs/testing'
@@ -8,7 +8,7 @@ describe('readFile', () => {
   test('reads the file', async () => {
     await temporary.directory(async (tmpDir) => {
       // Given
-      const filePath = pathJoin(tmpDir, 'file.txt')
+      const filePath = joinPath(tmpDir, 'file.txt')
       const content = 'content'
       await writeFile(filePath, content)
 

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -1,7 +1,7 @@
 export { useContext } from './context'
 export * as error from './error'
 export * as fs from './fs'
-export * as path from './path'
+export * as path from '../node/path.public'
 export * as plugin from './plugin'
 export * as configuration from './configuration'
 export * as target from './target'

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -1,7 +1,6 @@
 export { useContext } from './context'
 export * as error from './error'
 export * as fs from './fs'
-export * as path from '../node/path'
 export * as plugin from './plugin'
 export * as configuration from './configuration'
 export * as target from './target'

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -1,7 +1,7 @@
 export { useContext } from './context'
 export * as error from './error'
 export * as fs from './fs'
-export * as path from '../node/path.public'
+export * as path from '../node/path'
 export * as plugin from './plugin'
 export * as configuration from './configuration'
 export * as target from './target'

--- a/packages/info/src/cli/formatters/pretty.ts
+++ b/packages/info/src/cli/formatters/pretty.ts
@@ -12,12 +12,12 @@ export function prettyFormat(options: PrettyFormatOptions): string {
     `  ${terminal.formatBold('Name:')} ${options.project.configuration.name}`
   )
   lines.push(
-    `  ${terminal.formatBold('Directory:')} ${path.relativize(
+    `  ${terminal.formatBold('Directory:')} ${path.relativizePath(
       options.project.directory
     )}`
   )
   lines.push(
-    `  ${terminal.formatBold('Manifest:')} ${path.relativize(
+    `  ${terminal.formatBold('Manifest:')} ${path.relativizePath(
       options.project.configuration.manifestPath
     )}`
   )
@@ -55,12 +55,12 @@ export function prettyFormat(options: PrettyFormatOptions): string {
       lines.push(
         `${targetMetadataPrefix}${terminal.formatBold(
           `Directory:`
-        )} ${path.relativize(target.directory)}`
+        )} ${path.relativizePath(target.directory)}`
       )
       lines.push(
         `${targetMetadataPrefix}${terminal.formatBold(
           `Manifest:`
-        )} ${path.relativize(target.manifestPath)}`
+        )} ${path.relativizePath(target.manifestPath)}`
       )
     })
   }

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -35,11 +35,11 @@
     ]
   },
   "dependencies": {
-    "@gestaltjs/plugins": "^0.7.8",
     "@vitejs/plugin-react": "^1.3.1",
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
+    "@gestaltjs/core": "0.7.8",
     "@gestaltjs/plugins": "0.7.8",
     "@types/react-dom": "^18.0.2",
     "react": "^18.0.0",

--- a/packages/plugin-react/src/gestalt.plugin.integration.test.ts
+++ b/packages/plugin-react/src/gestalt.plugin.integration.test.ts
@@ -24,7 +24,7 @@ describe('plugin', () => {
     await temporary.directory(async (tmpDir) => {
       // Given
       const plugin = await ReactPlugin()
-      const outputFilePath = path.join(tmpDir, 'hydrate.js')
+      const outputFilePath = path.joinPath(tmpDir, 'hydrate.js')
 
       // When
       await buildWithRollup(plugin, outputFilePath)
@@ -118,7 +118,7 @@ async function getViteServer(
   componentModuleId: string,
   domElementSelector?: string
 ) {
-  const packageRoot = (await path.findUp('plugin-react', {
+  const packageRoot = (await path.findPathUp('plugin-react', {
     type: 'directory',
     cwd: path.moduleDirname(import.meta.url),
   })) as string

--- a/packages/plugin-react/src/gestalt.plugin.integration.test.ts
+++ b/packages/plugin-react/src/gestalt.plugin.integration.test.ts
@@ -2,11 +2,12 @@
 import ReactPlugin from './gestalt.plugin'
 import { describe, expect, test } from 'vitest'
 import { createServer } from 'vite'
-import { path, fs, Plugin } from '@gestaltjs/plugins'
+import { fs, Plugin } from '@gestaltjs/plugins'
 import { Plugin as RollupPlugin } from 'rollup'
 import { temporary } from '@gestaltjs/testing'
 import { rollup } from 'rollup'
 import esbuild from 'rollup-plugin-esbuild'
+import { findPathUp, joinPath, moduleDirname } from '@gestaltjs/core/node/path'
 
 describe('plugin', () => {
   test('ssr', async () => {
@@ -24,7 +25,7 @@ describe('plugin', () => {
     await temporary.directory(async (tmpDir) => {
       // Given
       const plugin = await ReactPlugin()
-      const outputFilePath = path.joinPath(tmpDir, 'hydrate.js')
+      const outputFilePath = joinPath(tmpDir, 'hydrate.js')
 
       // When
       await buildWithRollup(plugin, outputFilePath)
@@ -118,9 +119,9 @@ async function getViteServer(
   componentModuleId: string,
   domElementSelector?: string
 ) {
-  const packageRoot = (await path.findPathUp('plugin-react', {
+  const packageRoot = (await findPathUp('plugin-react', {
     type: 'directory',
-    cwd: path.moduleDirname(import.meta.url),
+    cwd: moduleDirname(import.meta.url),
   })) as string
   return await createServer({
     root: packageRoot,

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -35,10 +35,10 @@
     ]
   },
   "dependencies": {
-    "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42",
-    "@gestaltjs/plugins": "^0.7.8"
+    "@sveltejs/vite-plugin-svelte": "^1.0.0-next.42"
   },
   "devDependencies": {
+    "@gestaltjs/core": "0.7.8",
     "@gestaltjs/plugins": "0.7.8",
     "svelte": "^3.48.0",
     "vite": "2.9.9",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -35,10 +35,10 @@
     ]
   },
   "dependencies": {
-    "@vitejs/plugin-vue": "^2.3.1",
-    "@gestaltjs/plugins": "^0.7.8"
+    "@vitejs/plugin-vue": "^2.3.1"
   },
   "devDependencies": {
+    "@gestaltjs/core": "0.7.8",
     "@gestaltjs/plugins": "0.7.8",
     "vue": "^3.2.33",
     "vite": "2.9.9",

--- a/packages/plugin-vue/src/gestalt.plugin.integration.test.ts
+++ b/packages/plugin-vue/src/gestalt.plugin.integration.test.ts
@@ -68,7 +68,7 @@ async function getViteServer(
   componentModuleId: string,
   domElementSelector?: string
 ) {
-  const packageRoot = (await path.findUp('plugin-vue', {
+  const packageRoot = (await path.findPathUp('plugin-vue', {
     type: 'directory',
     cwd: path.moduleDirname(import.meta.url),
   })) as string

--- a/packages/plugin-vue/src/gestalt.plugin.integration.test.ts
+++ b/packages/plugin-vue/src/gestalt.plugin.integration.test.ts
@@ -1,8 +1,9 @@
 import VuePlugin from './gestalt.plugin'
 import { describe, expect, test } from 'vitest'
 import { createServer } from 'vite'
-import { path, Plugin } from '@gestaltjs/plugins'
+import { Plugin } from '@gestaltjs/plugins'
 import { Plugin as RollupPlugin } from 'rollup'
+import { findPathUp, moduleDirname } from '@gestaltjs/core/node/path'
 
 describe('plugin', () => {
   test('ssr', async () => {
@@ -68,9 +69,9 @@ async function getViteServer(
   componentModuleId: string,
   domElementSelector?: string
 ) {
-  const packageRoot = (await path.findPathUp('plugin-vue', {
+  const packageRoot = (await findPathUp('plugin-vue', {
     type: 'directory',
-    cwd: path.moduleDirname(import.meta.url),
+    cwd: moduleDirname(import.meta.url),
   })) as string
   return await createServer({
     root: packageRoot,

--- a/packages/plugins/src/runtime/index.ts
+++ b/packages/plugins/src/runtime/index.ts
@@ -1,4 +1,4 @@
-export { error, path, fs, useContext } from '@gestaltjs/core/shared'
+export { error, fs, useContext } from '@gestaltjs/core/shared'
 export { define as definePlugin } from './define'
 import { plugin } from '@gestaltjs/core/shared'
 export type Plugin = plugin.Plugin

--- a/packages/routes/src/cli/formatters/pretty.ts
+++ b/packages/routes/src/cli/formatters/pretty.ts
@@ -1,5 +1,5 @@
 import { project, terminal } from '@gestaltjs/core/cli'
-import { path } from '@gestaltjs/core/cli'
+import { path } from '@gestaltjs/core/node/path'
 
 type PrettyFormatOptions = {
   project: project.models.Project
@@ -12,12 +12,12 @@ export function prettyFormat(options: PrettyFormatOptions): string {
     `  ${terminal.formatBold('Name:')} ${options.project.configuration.name}`
   )
   lines.push(
-    `  ${terminal.formatBold('Directory:')} ${path.relativize(
+    `  ${terminal.formatBold('Directory:')} ${path.relativizePath(
       options.project.directory
     )}`
   )
   lines.push(
-    `  ${terminal.formatBold('Manifest:')} ${path.relativize(
+    `  ${terminal.formatBold('Manifest:')} ${path.relativizePath(
       options.project.configuration.manifestPath
     )}`
   )
@@ -43,12 +43,12 @@ export function prettyFormat(options: PrettyFormatOptions): string {
       lines.push(
         `${targetMetadataPrefix}${terminal.formatBold(
           `Directory:`
-        )} ${path.relativize(target.directory)}`
+        )} ${path.relativizePath(target.directory)}`
       )
       lines.push(
         `${targetMetadataPrefix}${terminal.formatBold(
           `Manifest:`
-        )} ${path.relativize(target.manifestPath)}`
+        )} ${path.relativizePath(target.manifestPath)}`
       )
     })
   }

--- a/packages/routes/src/cli/formatters/pretty.ts
+++ b/packages/routes/src/cli/formatters/pretty.ts
@@ -1,5 +1,5 @@
 import { project, terminal } from '@gestaltjs/core/cli'
-import { path } from '@gestaltjs/core/node/path'
+import { relativizePath } from '@gestaltjs/core/node/path'
 
 type PrettyFormatOptions = {
   project: project.models.Project
@@ -12,12 +12,12 @@ export function prettyFormat(options: PrettyFormatOptions): string {
     `  ${terminal.formatBold('Name:')} ${options.project.configuration.name}`
   )
   lines.push(
-    `  ${terminal.formatBold('Directory:')} ${path.relativizePath(
+    `  ${terminal.formatBold('Directory:')} ${relativizePath(
       options.project.directory
     )}`
   )
   lines.push(
-    `  ${terminal.formatBold('Manifest:')} ${path.relativizePath(
+    `  ${terminal.formatBold('Manifest:')} ${relativizePath(
       options.project.configuration.manifestPath
     )}`
   )
@@ -43,12 +43,12 @@ export function prettyFormat(options: PrettyFormatOptions): string {
       lines.push(
         `${targetMetadataPrefix}${terminal.formatBold(
           `Directory:`
-        )} ${path.relativizePath(target.directory)}`
+        )} ${relativizePath(target.directory)}`
       )
       lines.push(
         `${targetMetadataPrefix}${terminal.formatBold(
           `Manifest:`
-        )} ${path.relativizePath(target.manifestPath)}`
+        )} ${relativizePath(target.manifestPath)}`
       )
     })
   }

--- a/packages/website/docs/.vitepress/config.js
+++ b/packages/website/docs/.vitepress/config.js
@@ -126,6 +126,7 @@ function getContributorsSidebar() {
           children: [
             { text: 'fs', link: 'contributors/core/fs' },
             { text: 'npm', link: 'contributors/core/npm' },
+            { text: 'path', link: 'contributors/core/path' },
           ],
         },
       ],

--- a/packages/website/docs/contributors/core/path.md
+++ b/packages/website/docs/contributors/core/path.md
@@ -7,15 +7,15 @@ We abstract away the dependency with the runtime (e.g. Node) to ensure compatibi
 import { path } from "@gestaltjs/core"
 ```
 
-### `relativize`
+### `relativizePath`
 
 This function makes an absolute filesystem path relative to the current working directory. This is useful when logging paths to allow users to click on the file and let the OS open it in the editor of choice.
 
 ```ts
-import { path } from "@gestaltjs/core"
+import { relativizePath } from "@gestaltjs/core/node/path"
 
 // Working directory: /project/path
-const relativePath = path.relativize("/project/path/src/index.js")
+const relativePath = relativizePath("/project/path/src/index.js")
 // Result: src/index.js
 ```
 

--- a/packages/website/docs/contributors/core/path.md
+++ b/packages/website/docs/contributors/core/path.md
@@ -7,6 +7,140 @@ We abstract away the dependency with the runtime (e.g. Node) to ensure compatibi
 import * as path from "@gestaltjs/core/node/path"
 ```
 
+### `joinPath`
+
+Joins all given path components together using the platform-specific separator as a delimiter, then normalizes the resulting path.
+Zero-length path segments are ignored. If the joined path string is a zero-length string then '.' will be returned, representing the current working directory.
+
+```ts
+import { joinPath } from "@gestaltjs/core/node/path"
+
+const path = joinPath("/path/to/project", "src/index.js")
+// Result: /path/to/project/src/index.js
+```
+
+#### Arguments
+
+| Name | Description | Type | Required | Default |
+| --- | ------ | ---- | --- | ---- |
+| `components` | Path components | `string[]` | Yes | |
+
+#### Returns
+
+A `string` with the joint path.
+
+### `moduleDirname`
+
+This utility function replaces the CJS `__dirname` variable exposed by Node. This method is expected to be invoked passing the `import.meta.url` variable that represents the caller's module.
+
+```ts
+// Module: /path/to/project/src/index.js
+import { moduleDirname } from "@gestaltjs/core/node/path"
+
+const path = moduleDirname(import.meta.url)
+// Result: /path/to/project/src/
+```
+
+#### Arguments
+
+| Name | Description | Type | Required | Default |
+| --- | ------ | ---- | --- | ---- |
+| `url` | The value of `import.meta.url` in the caller module | `string` | Yes | |
+
+#### Returns
+
+The caller module's directory.
+
+
+### `parentDirectory`
+
+It returns the parent directory of a path.
+
+```ts
+import { parentDirectory } from "@gestaltjs/core/node/path"
+
+const parent = parentDirectory("/path/to/project/src/index.js")
+// Result: /path/to/project/src/
+```
+
+#### Arguments
+
+| Name | Description | Type | Required | Default |
+| --- | ------ | ---- | --- | ---- |
+| `path` | Path | `string` | Yes | |
+
+#### Returns
+
+A `string` with the path's parent directory.
+
+
+### `parsePath`
+
+Parses a string that represents a path and returns a [`path.ParsedPath`](https://nodejs.org/api/path.html#pathparsepath) instance that exposes attributes to access information about the path.
+
+```ts
+import { parsePath } from "@gestaltjs/core/node/path"
+
+const parsedPath = parsePath("/path/to/project/src/index.js")
+console.log(parsedPath.dir) // /path/to/project/src
+console.log(parsedPath.base) // index.js
+console.log(parsedPath.ext) // .js
+console.log(parsedPath.name) // index
+```
+
+#### Arguments
+
+| Name | Description | Type | Required | Default |
+| --- | ------ | ---- | --- | ---- |
+| `path` | Path to parse | `string` | Yes | |
+
+#### Returns
+
+An instance of [`path.ParsedPath`](https://nodejs.org/api/path.html#pathparsepath).
+
+### `pathBasename`
+
+It returns the last component of a path.
+
+```ts
+import { pathBasename } from "@gestaltjs/core/node/path"
+
+const basename = pathBasename("/path/to/project/src/index.js")
+// Result: index.js
+```
+
+#### Arguments
+
+| Name | Description | Type | Required | Default |
+| --- | ------ | ---- | --- | ---- |
+| `path` | Path | `string` | Yes | |
+
+#### Returns
+
+A `string` with the path's last component.
+
+### `relativePath`
+
+Solve the relative path from {from} to {to}. At times we have two absolute paths, and we need to derive the relative path from one to the other.
+
+```ts
+import { relativePath } from "@gestaltjs/core/node/path"
+
+const relativePath = relativePath("/path/to/project", "/path/to/project/src/index.js")
+// Result: src/index.js
+```
+
+#### Arguments
+
+| Name | Description | Type | Required | Default |
+| --- | ------ | ---- | --- | ---- |
+| `from` | Path used as a reference. | `string` | Yes | |
+| `to` | Path to relativize. | `string` | Yes | |
+
+#### Returns
+
+The `to` path made relative to `from`.
+
 ### `relativizePath`
 
 This function makes an absolute filesystem path relative to the current working directory. This is useful when logging paths to allow users to click on the file and let the OS open it in the editor of choice.
@@ -30,14 +164,36 @@ const relativePath = relativizePath("/project/path/src/index.js")
 The path relative to the current working directory.
 
 
-### `fromURL`
+### `resolvePath`
+
+It resolves a sequence of paths or path segments into an absolute path.
+
+```ts
+import { resolvePath } from "@gestaltjs/core/node/path"
+
+// Working directory: /project/path
+const resolvedPath = resolvePath("src", "index.js")
+// Result: /project/path/src/index.js
+```
+
+#### Arguments
+
+| Name | Description | Type | Required | Default |
+| --- | ------ | ---- | --- | ---- |
+| `pathComponents` | the path components. | `string[]` | Yes | |
+
+#### Returns
+
+A `string` with the ressolved absolute path.
+
+### `pathFromURL`
 
 This function ensures the correct decodings of percent-encoded characters as well as ensuring a cross-platform valid absolute path string.
 
 ```ts
 import { pathFromURL } from "@gestaltjs/core/node/path"
 
-const resolvedPath = path.pathFromURL("file://nas/foo.txt")
+const resolvedPath = pathFromURL("file://nas/foo.txt")
 ```
 
 #### Arguments

--- a/packages/website/docs/contributors/core/path.md
+++ b/packages/website/docs/contributors/core/path.md
@@ -4,7 +4,7 @@
 We abstract away the dependency with the runtime (e.g. Node) to ensure compatibility across OSs and Javascript runtimes:
 
 ```ts
-import { path } from "@gestaltjs/core"
+import * as path from "@gestaltjs/core/node/path"
 ```
 
 ### `relativizePath`
@@ -35,9 +35,9 @@ The path relative to the current working directory.
 This function ensures the correct decodings of percent-encoded characters as well as ensuring a cross-platform valid absolute path string.
 
 ```ts
-import { path } from "@gestaltjs/core"
+import { pathFromURL } from "@gestaltjs/core/node/path"
 
-const resolvedPath = path.fromURL("file://nas/foo.txt")
+const resolvedPath = path.pathFromURL("file://nas/foo.txt")
 ```
 
 #### Arguments

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,8 @@ importers:
 
   packages/plugin-react:
     specifiers:
-      '@gestaltjs/plugins': ^0.7.8
+      '@gestaltjs/core': 0.7.8
+      '@gestaltjs/plugins': 0.7.8
       '@types/react-dom': ^18.0.2
       '@vitejs/plugin-react': ^1.3.1
       esbuild: ^0.14.39
@@ -320,10 +321,11 @@ importers:
       rollup: ^2.73.0
       rollup-plugin-esbuild: ^4.9.1
     dependencies:
-      '@gestaltjs/plugins': link:../plugins
       '@vitejs/plugin-react': 1.3.1
       react-dom: 18.0.0_react@18.0.0
     devDependencies:
+      '@gestaltjs/core': link:../core
+      '@gestaltjs/plugins': link:../plugins
       '@types/react-dom': 18.0.2
       esbuild: 0.14.39
       react: 18.0.0
@@ -332,7 +334,8 @@ importers:
 
   packages/plugin-svelte:
     specifiers:
-      '@gestaltjs/plugins': ^0.7.8
+      '@gestaltjs/core': 0.7.8
+      '@gestaltjs/plugins': 0.7.8
       '@sveltejs/vite-plugin-svelte': ^1.0.0-next.42
       esbuild: ^0.14.39
       rollup: ^2.73.0
@@ -340,9 +343,10 @@ importers:
       svelte: ^3.48.0
       vite: 2.9.9
     dependencies:
-      '@gestaltjs/plugins': link:../plugins
       '@sveltejs/vite-plugin-svelte': 1.0.0-next.42_svelte@3.48.0+vite@2.9.9
     devDependencies:
+      '@gestaltjs/core': link:../core
+      '@gestaltjs/plugins': link:../plugins
       esbuild: 0.14.39
       rollup: 2.74.1
       rollup-plugin-esbuild: 4.9.1_3pm4nepjd6vnmqn35npt5y2clm
@@ -351,7 +355,8 @@ importers:
 
   packages/plugin-vue:
     specifiers:
-      '@gestaltjs/plugins': ^0.7.8
+      '@gestaltjs/core': 0.7.8
+      '@gestaltjs/plugins': 0.7.8
       '@vitejs/plugin-vue': ^2.3.1
       esbuild: ^0.14.39
       rollup: ^2.73.0
@@ -359,9 +364,10 @@ importers:
       vite: 2.9.9
       vue: ^3.2.33
     dependencies:
-      '@gestaltjs/plugins': link:../plugins
       '@vitejs/plugin-vue': 2.3.1_vite@2.9.9+vue@3.2.33
     devDependencies:
+      '@gestaltjs/core': link:../core
+      '@gestaltjs/plugins': link:../plugins
       esbuild: 0.14.39
       rollup: 2.74.1
       rollup-plugin-esbuild: 4.9.1_3pm4nepjd6vnmqn35npt5y2clm

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,7 @@
     "inlineSourceMap": true,
     "isolatedModules": false,
     "paths": {
+      "@gestaltjs/core/node/path": ["../../core/src/node/path.public.ts"],
       "@gestaltjs/core/shared": ["../../core/src/shared/index.ts"],
       "@gestaltjs/core/runtime": ["../../core/src/runtime/index.ts"],
       "@gestaltjs/core/cli": ["../../core/src/cli/index.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,7 @@
     "inlineSourceMap": true,
     "isolatedModules": false,
     "paths": {
-      "@gestaltjs/core/node/path": ["../../core/src/node/path.public.ts"],
+      "@gestaltjs/core/node/path": ["../../core/src/node/path.ts"],
       "@gestaltjs/core/shared": ["../../core/src/shared/index.ts"],
       "@gestaltjs/core/runtime": ["../../core/src/runtime/index.ts"],
       "@gestaltjs/core/cli": ["../../core/src/cli/index.ts"],


### PR DESCRIPTION
## What?
This is the first PR of some to follow to shift our approach to how we export modules with the aim to improve the developer ergonomics contributing to this project. In a nutshell, we are moving from imports like:

```ts
import { path } from "@gestaltjs/core/cli"
```

To

```ts
import { relativizePath } from "@gestaltjs/core/node/cli"
```
## Why?

Until now, we exported all the public modules through an `index.ts` module. While that works, it makes mocking inconvenient because a mocking of `@gestaltjs/core` through Vitest mocks all the modules that are exported through it.


## How?

- Adjusted the Rollup configuration file of `@gestaltjs/core` to output the files suffixed as `.public.ts` under `src/node`
- Adjusted the Typescript paths to resolve imports in development.
- Added a new entry to the `exports` section of core's `package.json`.

## Testing?

A passing CI should make us feel confidence this change hasn't broken anything. Alternatively, you can run `pnpm run build` in the `core` directory.

## Anything Else? (optional)

Once this PR is merged, I'll continue with the other modules. I'll take the opportunity to revisit the APIs and document modules that lack documentation.