### PR TITLE
Make errors inherit from `ExtendableError`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,6 +86,7 @@
     "stacktracey": "^2.1.8",
     "tempy": "^2.0.0",
     "terminal-link": "^3.0.0",
+    "ts-error": "^1.0.6",
     "unified": "^10.1.2",
     "vite": "^2.9.12"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,7 @@ importers:
       stacktracey: ^2.1.8
       tempy: ^2.0.0
       terminal-link: ^3.0.0
+      ts-error: ^1.0.6
       unified: ^10.1.2
       vite: ^2.9.12
     dependencies:
@@ -173,6 +174,7 @@ importers:
       stacktracey: 2.1.8
       tempy: 2.0.0
       terminal-link: 3.0.0
+      ts-error: 1.0.6
       unified: 10.1.2
       vite: 2.9.12
     devDependencies:
@@ -12951,6 +12953,10 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
     dev: true
+
+  /ts-error/1.0.6:
+    resolution: {integrity: sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==}
+    dev: false
 
   /ts-node/10.8.1_x2utdhayajzrh747hktprshhby:
     resolution: {integrity: sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==}


### PR DESCRIPTION
## What?
I'm making all the errors extend from a `FatalError` class, which inherits from an [`ExtendableError`](https://www.npmjs.com/package/ts-error) class all the shortcomings that arise with error subclassing.

## Why?
A great error handling experience requires some categorizing the errors to handle them appropriately based on the error category. For example, if it's an abort, the error handling logic doesn't need to print the stack trace to the user. This presents us with the question: *how do we categorize them?* Because error handling in Javascript centers around the OOP-based through the `Error` class, the natural inclination is using subclasses to represent categories and adding additional properties.  However, because the `Error` class is not designed for inheritance, there are [some shortcomings](https://www.npmjs.com/package/ts-error) that make them hard to work with. The most notable one are not being able to check the type by using `instanceof` and add additional properties.
