### PR TITLE
Add a utility to watch for file changes

### DIFF
--- a/.changeset/tasty-fishes-impress.md
+++ b/.changeset/tasty-fishes-impress.md
@@ -1,0 +1,5 @@
+---
+'@gestaltjs/core': minor
+---
+
+Add a utility to watch for file and dir changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,7 @@
     "@remix-run/web-fetch": "^4.2.0",
     "acorn": "8.8.1",
     "case-anything": "2.1.10",
+    "chokidar": "3.5.3",
     "commondir": "1.0.1",
     "esbuild": "0.16.4",
     "execa": "6.1.0",

--- a/packages/core/src/private/node/file-watcher.integration.test.ts
+++ b/packages/core/src/private/node/file-watcher.integration.test.ts
@@ -1,0 +1,37 @@
+import { inTemporaryDeletableDirectory } from '../../internal/node/testing/temporary.js'
+import { describe, test, afterEach, expect } from 'vitest'
+import { FileWatcher, FileWatcherEvent, watchFiles } from './file-watcher.js'
+import { AbsolutePath } from 'typed-file-system-path'
+import { writeFile } from '../../public/node/fs.js'
+
+let fileWatcher: FileWatcher | undefined
+
+afterEach(async () => {
+  await fileWatcher?.close()
+})
+
+describe('watchFiles', () => {
+  test('notifies when a new file gets added', async () => {
+    await inTemporaryDeletableDirectory(async (tmpDir) => {
+      // Given
+      const filePath = tmpDir.pathAppendingComponent('test.ts')
+
+      // When
+      const [event, path] = await new Promise<[FileWatcherEvent, AbsolutePath]>(
+        (resolve, reject) => {
+          const fileWriting = writeFile(filePath, "const test = 'test'")
+          fileWatcher = watchFiles({
+            patterns: tmpDir.pathAppendingComponent('**/*').pathString,
+            on: (event, path) => {
+              resolve([event, path])
+            },
+          })
+          fileWriting.catch((error) => reject)
+        }
+      )
+      // Then
+      expect(event).toEqual('add')
+      expect(path).toEqual(filePath)
+    })
+  })
+})

--- a/packages/core/src/private/node/file-watcher.test.ts
+++ b/packages/core/src/private/node/file-watcher.test.ts
@@ -1,0 +1,40 @@
+import { describe, vi, test, expect } from 'vitest'
+import chokidar from 'chokidar'
+import { watchFiles } from './file-watcher.js'
+import { absolutePath } from 'typed-file-system-path'
+
+vi.mock('chokidar', () => ({
+  default: {
+    watch: vi.fn(),
+  },
+}))
+
+describe('watchFiles', () => {
+  test('it delegates file-watching to chokidar', async () => {
+    // Given
+    const fileWatcher = {
+      on: vi.fn(),
+      close: vi.fn(),
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    vi.mocked(chokidar.watch).mockReturnValue(fileWatcher as any)
+
+    // When
+    const options: Parameters<typeof watchFiles>[0] = {
+      patterns: '**/*',
+      on: vi.fn(),
+    }
+    const subject = watchFiles(options)
+
+    // Then
+    expect(chokidar.watch).toHaveBeenCalledWith('**/*', { persistent: true })
+    expect(fileWatcher.on).toHaveBeenCalledWith('all', expect.anything())
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const allCallback: any = vi.mocked(fileWatcher.on).mock.calls[0][1]
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    allCallback('all', '/index.ts')
+    expect(options.on).toHaveBeenCalledWith('all', absolutePath('/index.ts'))
+    await subject.close()
+    expect(fileWatcher.close).toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/private/node/file-watcher.ts
+++ b/packages/core/src/private/node/file-watcher.ts
@@ -1,0 +1,38 @@
+import chokidar from 'chokidar'
+import { absolutePath, AbsolutePath } from 'typed-file-system-path'
+
+/**
+ * A union representing the file-watching events that are available.
+ */
+export type FileWatcherEvent =
+  | 'add'
+  | 'addDir'
+  | 'change'
+  | 'unlink'
+  | 'unlinkDir'
+
+export type FileWatcher = {
+  /** It closes the file watcher */
+  close: () => Promise<void>
+}
+
+export type WatchFilesOptions = {
+  /** Patterns used to filter file-watching events */
+  patterns: string | ReadonlyArray<string>
+  /** Callback that's invoked on file-watching events */
+  on: (event: FileWatcherEvent, path: AbsolutePath) => void
+}
+
+/**
+ * It watches for directory and file changes and notifies updates.
+ * @returns A FileWatcher instance.
+ */
+export function watchFiles(options: WatchFilesOptions): FileWatcher {
+  const fileWatcher = chokidar.watch(options.patterns, {
+    persistent: true,
+  })
+  fileWatcher.on('all', (event, path: string) => {
+    options.on(event, absolutePath(path))
+  })
+  return fileWatcher
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,7 @@ importers:
       '@types/inquirer': 9.0.3
       acorn: 8.8.1
       case-anything: 2.1.10
+      chokidar: ^3.5.3
       commondir: 1.0.1
       esbuild: 0.16.4
       execa: 6.1.0
@@ -158,6 +159,7 @@ importers:
       '@remix-run/web-fetch': 4.2.0
       acorn: 8.8.1
       case-anything: 2.1.10
+      chokidar: 3.5.3
       commondir: 1.0.1
       esbuild: 0.16.4
       execa: 6.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,7 +121,7 @@ importers:
       '@types/inquirer': 9.0.3
       acorn: 8.8.1
       case-anything: 2.1.10
-      chokidar: ^3.5.3
+      chokidar: 3.5.3
       commondir: 1.0.1
       esbuild: 0.16.4
       execa: 6.1.0


### PR DESCRIPTION
## What?
I'm adding a new private module to `@gestaltjs/core` that uses `chokidar` internally to watch for changes.

## Why?
We'll need to observe for file changes for hot-reloading capabilities.